### PR TITLE
RFC Proposal - Changes to multi-document streams

### DIFF
--- a/rfc/RFC-bare-flow-docs-newline.md
+++ b/rfc/RFC-bare-flow-docs-newline.md
@@ -1,0 +1,78 @@
+RFC-000
+=======
+
+Any two bare-flow-documents may be separated by a newline
+
+
+| Key | Value |
+| --- | --- |
+| Target | 1.5 |
+| Status | 0 |
+| Requires | [RFC-json-streaming](RFC-json-streaming.md), [RFC-top-plain-single-line](RFC-top-plain-single-line.md) |
+| Related | [RFC-directives-are-stream](RFC-directives-are-stream.md) |
+| Discuss | [Issue 0](../../issues/0) |
+| Tags | [bare]() [document]() [flow]() |
+
+
+## Problem
+
+While JSON itself does not support streaming or otherwise allow multiple separate documents to be defined in a single file, [JSON streaming](https://en.wikipedia.org/wiki/JSON_streaming) does.
+The term refers to a family of protocols such as JSON Lines that allow the concatenation of multiple JSON documents, most often by using a newline `\n` as a delimiter.
+These are not currently supported by YAML, but they could be.
+
+[RFC-json-streaming](RFC-json-streaming.md) adds support for line-delimited JSON consisting only of collections; this is about also supporting JSON scalars.
+
+
+## Proposal
+
+This RFC has a precondition that a bare document with untagged top-level plain scalar contents can be unambiguously determined to be a JSON `null`, `true`, `false`, or a JSON number if it starts with characters that would match one of those patterns.
+How exactly that should happen is a separate issue, and addressed e.g. in [RFC-top-plain-single-line](RFC-top-plain-single-line.md).
+
+Provided the preceding happens, the first paragraph of the [RFC-json-streaming](RFC-json-streaming.md) proposal is amended to refer to all flow nodes, rather then only flow collections:
+
+Adjacent documents with root-level flow nodes do not need a document marker separating them, but do need at least one newline `\n` between them.
+
+A valid stream of three documents:
+
+```
+"first quoted string"
+[ second, doc ]
+42
+```
+
+Comments and empty lines between such documents are allowed, and flow nodes are not required to fit on a single line:
+
+```
+{
+  first: doc
+}
+
+# this is fine
+'second,
+
+  doc'
+```
+
+Using no separator, or only whitespace not including `\n` as a separator, is an error:
+
+```
+# ERROR
+"not" { fine }
+```
+
+
+## Explanation
+
+In order to support line-delimited JSON scalar values, the meaning of the following stream will need to change:
+
+```
+true
+true
+true
+```
+
+In YAML 1.2, that parses as a top-level scalar with the value `"true true true\n"`.
+As line-delimited JSON, that would parse as three documents each with the boolean value `true`.
+
+In order for YAML to also be able to parse that as three `true` documents, plain untagged scalar values other than `true`, `false`, `null` and JSON numbers need to not be allowed at the top level of a document.
+This RFC does not suggest if or how that should happen, but if it does become possible to unambiguously parse a document as ending after any possible JSON scalar value, that the relaxation of needing only a newline separator between documents should be extended from flow collections to also cover JSON scalar values.

--- a/rfc/RFC-directives-are-stream.md
+++ b/rfc/RFC-directives-are-stream.md
@@ -1,0 +1,93 @@
+RFC-000
+=======
+
+Directives belong to the stream and not a document
+
+
+| Key | Value |
+| --- | --- |
+| Target | 1.5 |
+| Status | 0 |
+| Requires | [RFC-tail-docs-require-header](RFC-tail-docs-require-header.md) |
+| Related | [RFC-json-streaming](RFC-json-streaming.md) |
+| Discuss | [Issue 0](../../issues/0) |
+| Tags | [directive]() [document]() [stream]() |
+
+
+## Problem
+
+The YAML 1.1 spec defines a stream as consisting of a series of documents, each of which "may be preceded by a series of directives."
+Documents after the first (`l-next-document`) have this additional specification:
+> If the document specifies no directives, it is parsed using the same settings as the previous document.
+> If the document does specify any directives, all directives of previous documents, if any, are ignored.
+
+In the YAML 1.2 spec, a document in a stream "is completely independent from the rest".
+This version of the spec does not define an `l-next-document` construct, but does define an `l-directive-document` as starting "with some directives".
+
+The complete independence of documents from each other severely limits the usability of multi-document streams, in particular with repect to directives.
+The YAML 1.1 implementation should be returned to, while clarifying the relationship between documents and directives.
+
+
+## Proposal
+
+This RFC follows on from [RFC-tail-docs-require-header](RFC-tail-docs-require-header.md), which renames the "directives end" marker as "document start" and requires it for documents after the first in a stream.
+
+Directives are defined as belonging to the stream, rather than any single document.
+Each directive may be repeated, and a directive with the same name as an earlier directive completely replaces the earlier directive.
+Directives may themselves limit whether they may be repeated, or defined after the first document.
+When parsing a document, only the values of directives declared before that document are taken into account.
+
+If any directives are declared before the first document, that document must have a document-start marker.
+If directives need to be set between documents, the preceding document must have a document-end marker.
+
+A stream therefore consists of a sequence of four different constructs, each of which may be parsed a single line at a time:
+* `empty` lines, consisting only of white space
+* `comment` lines, which have `#` as their first non-white-space character
+* `directive` lines, which start with `%`
+* documents, which may include:
+  * document `start` (line starts with `---`) and `end` (line starts with `...`) markers as well as
+  * all `other` valid document constructs, which includes `empty` and `comment` lines.
+
+The stream parser may be implemented based on a state machine that is in one of three states.
+At any point, `empty` lines and `comment`s may be encountered; they are not considered here.
+1. `START`: The state at the beginning of the stream.
+   When encountering the first non-`empty` non-`comment` construct, the state switches to `STREAM` if it is a `directive` or to `DOCUMENT` if it is `start` or `other`.
+   Encountering `end` here is an error.
+2. `STREAM`: Only `directive` and `start` are valid constructs, everything else is an error.
+   When encountering `start`, the state switches to `DOCUMENT`.
+3. `DOCUMENT`:
+   When encountering `start`, any previous document ends and a new document is started.
+   After encountering `end`, the document ends and the stream state switches to `STREAM`.
+   Within a document, `directive` parsing does not take place and `other` constructs may occur.
+
+The stream may end at any point, at which any remaining document should be considered to end.
+On output, implementations should include all directives before the first document, if possible.
+
+For single-document streams, this matches the behaviour of YAML 1.1 and YAML 1.2.
+For multi-document streams, this matches the behaviour of YAML 1.1.
+Compared to YAML 1.2, there is a difference in directives preceding earlier documents also being taken into accound when parsing.
+
+If both [RFC-json-streaming](RFC-json-streaming.md) and this are accepted, certain `other` constructs such as flow mappings and sequences may begin a new document when within the `DOCUMENT` state.
+
+OK:
+```
+plain: document
+```
+
+OK:
+```
+%YAML 1.3
+%TAG ! !foo/
+---
+document: with directives
+...
+
+%TAG ! !bar/
+---
+other: document with redefined ! tag
+```
+
+Error:
+```
+...
+```

--- a/rfc/RFC-json-streaming.md
+++ b/rfc/RFC-json-streaming.md
@@ -1,0 +1,69 @@
+RFC-000
+=======
+
+Bare documents of flow collections may be separated by a newline
+
+
+| Key | Value |
+| --- | --- |
+| Target | 1.5 |
+| Status | 0 |
+| Requires | [RFC-tail-docs-require-header](RFC-tail-docs-require-header.md) |
+| Related | [RFC-top-plain-single-line](RFC-top-plain-single-line.md) |
+| Discuss | [Issue 0](../../issues/0) |
+| Tags | [bare]() [document]() [flow]() |
+
+
+## Problem
+
+While JSON itself does not support streaming or otherwise allow multiple separate documents to be defined in a single file, [JSON streaming](https://en.wikipedia.org/wiki/JSON_streaming) does.
+The term refers to a family of protocols such as JSON Lines that allow the concatenation of multiple JSON documents, most often by using a newline `\n` as a delimiter.
+These are not currently supported by YAML, but they could be.
+
+
+## Proposal
+
+Adjacent documents with root-level flow collection values do not need a document marker separating them, but do need at least one newline `\n` between them.
+
+On output, YAML libraries SHOULD by default include a `---` separator for documents even if the output could be parsed as valid YAML without it.
+If it's desirable for the output to be parsed by non-YAML line-delimited JSON consumers, each document SHOULD be formatted as valid JSON and output on a single line.
+
+A valid stream of three documents:
+
+```
+{ "first": "doc" }
+[ second, doc ]
+{ third }
+```
+
+Comments and empty lines between such documents are allowed, and flow collections are not required to fit on a single line:
+
+```
+{
+  first: doc
+}
+
+# this is fine
+[
+    second,
+    doc
+]
+```
+
+Using no separator, or only whitespace not including `\n` as a separator, is an error:
+
+```
+# ERROR
+[ not ] { fine }
+```
+
+## Explanation
+
+Normally, documents after the first in a stream need a document marker separating them to ensure clarity.
+For flow mappings and sequences, this is not required as there is no ambiguity.
+Requiring at least one newline `\n` as a separator makes it more obvious that the documents are intentionally separated, and clarifies the starting index of the second document
+
+This change could be considered semver-minor, as it does not change any existing working code.
+This would also support parsing most real-world line-delimited JSON, but it would not support JSON streams that may contain documents that are JSON scalar values.
+
+For complete line-delimited JSON support, see [RFC-top-plain-single-line](RFC-top-plain-single-line.md), which builds on this and other spec changes.

--- a/rfc/RFC-tail-docs-require-header.md
+++ b/rfc/RFC-tail-docs-require-header.md
@@ -1,0 +1,60 @@
+RFC-000
+=======
+
+Documents after the first require a document-start-indicator
+
+
+| Key | Value |
+| --- | --- |
+| Target | 1.5 |
+| Status | 0 |
+| Requires | |
+| Related | [RFC-json-streaming](RFC-json-streaming.md), [RFC-directives-are-stream](RFC-directives-are-stream.md) |
+| Discuss | [Issue 0](../../issues/0) |
+| Tags | [document]() [indicator]() |
+
+
+## Problem
+
+YAML supports two document markers, `---` and `...`.
+Their roles and usage is not entirely clear.
+The YAML 1.2 spec refers to these as the "directives end" and the "document end" markers or indicators.
+The YAML 1.1 spec referred to `---` as the "document start" marker.
+
+
+## Proposal
+
+The "directives end" marker should be renamed back to "document start", and be explicitly required when starting any document after the first in a stream.
+The "document end" marker would continue to be optional, and useful far more rarely:
+
+* When needing to include directives between documents.
+* Explicitly ending a document in a persistent stream.
+
+
+## Explanation
+
+The `...` (document end) indicator was originally proposed to explicitly end a document in a streaming operation in situations where the next document might take too much time to appear.
+The next document, starting with `---`, would effectively end the previous document, in the absence of the document end indicator.
+
+Later on, it was noted that in the presence of `...`, the `---` for the next document was not really needed.
+This, in turn, led to the renaming of `---` to "directives end" which while possibly technically correct, obsured the true meaning and purpose of `---`.
+
+This proposal and its related ones, bring back the original meaning to the indicators, require the start indicator to start a subsequent document, and make a clear distinction between stream-related content and document-related content.
+
+OK:
+```
+doc: 1
+---
+doc: 2
+...
+%TAG ! !foo/
+--- !bar
+doc: 3
+```
+
+Error:
+```
+doc: 1
+...
+doc: 2
+```

--- a/rfc/RFC-top-plain-single-line.md
+++ b/rfc/RFC-top-plain-single-line.md
@@ -1,0 +1,73 @@
+RFC-000
+=======
+
+Top-level plain scalars must not contain newline characters
+
+
+| Key | Value |
+| --- | --- |
+| Target | 1.5 |
+| Status | 0 |
+| Requires | |
+| Related | [RFC-json-streaming](RFC-json-streaming.md), [RFC-bare-flow-docs-newline](RFC-bare-flow-docs-newline.md) |
+| Discuss | [Issue 0](../../issues/0) |
+| Tags | [foo]() [bar]() |
+
+
+## Problem
+
+Documents with scalar (rather than collection) contents are a valid but relatively rare case which needs to be accounted for.
+In particular, it is desirable for YAML to continue to be a complete superset of JSON, which also allows for scalar documents.
+As it is also desirable for YAML to be a superset of line-delimited JSON (see [RFC-json-streaming](RFC-json-streaming.md), [RFC-bare-flow-docs-newline](RFC-bare-flow-docs-newline.md)), the rules for top-level plain scalars should be tightened.
+
+
+## Proposal
+
+
+Top-level plain scalars MUST NOT contain newline characters.
+
+
+## Explanation
+
+JSON includes the following plain scalar values:
+
+- `null`
+- `true`
+- `false`
+- numbers, e.g. `42`, `1.23`, `-9e9`
+
+YAML schemas commonly include additional plain scalar values which use default resolution based on regular expressions, rather than needing an explicit tag.
+For example, the core schema supports using `0xCAFE` to represent a hexadecimal numbers.
+Limiting top-level plain scalars to not include newline characters allows for practically all default-resolution values to still be used at the top level, while disambiguating consecutive newline-separated documents from each other.
+
+This change does not limit the expressibility of the language, as values with newlines may still be used even at the top level, provided that they use some form of flow or block quoting.
+Similarly, values including newlines that would normally use regexp-based default resolution may still be used at the top level, provided that they use an explicit tag and quote their value.
+
+Each of these lines consists of a valid YAML document:
+
+```
+42
+true
+plain string
+'quoted string'
+!!null explicitly tagged value
+```
+
+Top-level block scalars are still accepted:
+
+```
+>
+  A block of text.
+
+--- |
+  This is
+  fine.
+```
+
+This would be parsed as two separate documents:
+
+```
+--- !!str
+Even explicitly tagging
+as string is not enough.
+```


### PR DESCRIPTION
This PR includes five separate but interlinked RFCs. Briefly, it moves the "ownership" of directives from documents to the stream, clarifies how documents ought to be separated, and then proceeds to make YAML not only a superset of JSON, but also of [line-delimited JSON](https://en.wikipedia.org/wiki/JSON_streaming).

Some of the RFCs here should be pretty straightforward to accept, but others are more questionable, in particular as the handling and limitations of top-level scalars need to be adjusted in order to make it possible to handle as in line-delimited JSON.