### PR TITLE
Meta: Add CODEOWNERS file to auto-assign RFC proposals for core team review

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+/rfc/* @ingydotnet @perlpunk @eemeli @pantoniou


### PR DESCRIPTION
Documentation here: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners