### PR TITLE
Add Docker support for the 1.2 build process

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,19 @@
+name: yaml-spec Testing
+
+on:
+  push:
+    # branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test-make-targets:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Make the 1.2 spec.html from docbook
+      run:
+        source .rc &&
+        make -C 1.2 clean html

--- a/.rc
+++ b/.rc
@@ -1,0 +1,31 @@
+# shellcheck shell=bash
+
+[[ -n ${ZSH_VERSION-} ]] &&
+  YAML_SPEC_ROOT="$0" ||
+  YAML_SPEC_ROOT="${BASH_SOURCE[0]}"
+
+YAML_SPEC_ROOT=$(cd "$(dirname "$YAML_SPEC_ROOT")" && pwd)
+
+if [[ ! -e "$YAML_SPEC_ROOT/ext" ]]; then
+  (
+    cd "$YAML_SPEC_ROOT" || exit $?
+    make ext &>/dev/null
+  )
+fi
+
+(
+  set -e
+  command -v python3 >/dev/null || {
+    echo "yaml-spec/.rc requires 'python3'"
+    exit 1
+  }
+  python3 -c 'import yaml' 2>/dev/null || {
+    echo "yaml-spec/.rc requiress the Python 'pyyaml' package"
+    echo "Try 'pip3 install pyyaml'"
+    exit 1
+  }
+) || return $?
+
+export YAML_SPEC_ROOT
+
+# vim: set ft=sh:

--- a/1.2/.gitignore
+++ b/1.2/.gitignore
@@ -1,1 +1,4 @@
 /spec/
+/*.html
+/docbook_xslt
+

--- a/1.2/Makefile
+++ b/1.2/Makefile
@@ -1,3 +1,7 @@
+DOCKER_TOOL := docbook-builder
+include ../tool/make/init.mk
+
+
 .SUFFIXES: .dbk .html .dia .eps .png .pdf
 
 # To make this work, you need:
@@ -81,7 +85,10 @@ site: all
 site.tgz: site
 	cd site && tar cvzf ../site.tgz *
 
-html: $(HTML)
+ifeq ($(wildcard /.dockerenv),)
+html:
+	$(call docker-run,make $(HTML))
+endif
 
 pdf: $(PDF)
 
@@ -104,8 +111,11 @@ $(PDF): single_fo.xsl ebnf_fo.xsl preprocess_fo.xsl
 
 $(HTML): single_html.xsl preprocess_html.xsl
 
+ifneq ($(wildcard /.dockerenv),)
 .dbk.html: single_html.xsl catalog docbook_xslt
 	$(XSLTPROC) single_html.xsl $*.dbk > $*.html
+	chown -R --reference=Makefile $@
+endif
 
 .dbk.pdf: single_fo.xsl Render-X-license.txt catalog docbook_xslt
 	$(XSLTPROC) --param generate.toc "''" single_fo.xsl $*.dbk | sed 's/\xa0/\&#160;/g;s/\xa9/\&#169;/' > tmp.xml
@@ -157,6 +167,10 @@ spec.pdf: spec.dbk \
 	ps2pdf spec.ps
 	rm tmp*.xml
 
+ifeq ($(wildcard /.dockerenv),)
+spec.html: spec.dbk
+	$(call docker-run,make spec.html)
+else
 spec.html: spec.dbk \
            preprocess_png.sed preprocess_html.pl catalog docbook_xslt
 	perl verify_lhs.pl < spec.dbk
@@ -166,6 +180,8 @@ spec.html: spec.dbk \
 	$(XSLTPROC) single_html.xsl tmp2.xml > tmp3.xml
 	perl preprocess_html.pl tmp3.xml > spec.html
 	rm tmp*.xml
+	chown -R --reference=Makefile .
+endif
 
 docbook_xslt:
 	ln -s $(DOCBOOK_XSLT) docbook_xslt

--- a/1.2/ReadMe.md
+++ b/1.2/ReadMe.md
@@ -5,22 +5,20 @@ The YAML Specification
 
 ## Overview
 
-This repository contains the source materials and build files for the [YAML
-Specification](http://www.yaml.org/spec/1.2/spec.html).
+This directory contains the source materials and build files for the
+[YAML 1.2 Specification](http://www.yaml.org/spec/1.2/spec.html).
 
 ## Build Process
 
-To turn these files into HTML and PDF representations of the spec, you can run:
-`make all`, but that requires a lot of prerequisites to be installed. The
-easier method is to do this (requires Docker):
-
+To turn these files into HTML, run (from the top level directory):
 ```
-git clone https://github.com/yaml/yaml-spec-builder-docker
-cd yaml-spec-builder-docker
-make spec
+source .rc
+make -C 1.2 html
 ```
 
-## Contributing
+The build system requires:
 
-Contributions are welcome. File issues and pull requests
-[here](https://github.com/yaml/yaml-spec/issues).
+* make
+* docker
+* python3
+  * pyyaml

--- a/tool/bin/yaml-to-dockerfile
+++ b/tool/bin/yaml-to-dockerfile
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import sys
+import yaml
+import tempfile
+
+class YamlToDockerfile():
+    @classmethod
+    def run(cls, args):
+        self = cls(args)
+
+        data = yaml.safe_load(open(self.file))
+        if isinstance(data, list):
+            data = { 'steps': data }
+
+        dockerfile = self.format(data)
+
+        temp_file = tempfile.mkdtemp() + '/Dockerfile'
+        temp = open(temp_file, 'w+')
+
+        temp.write(dockerfile)
+
+        print(temp_file)
+
+    def __init__(self, args):
+        self.file, self.opts = self.getopt(args)
+
+    def getopt(self, args):
+        return args[0], {}
+
+    def format(self, data):
+        lines = []
+
+        for step in data.get('steps'):
+            for key, val in step.items():
+                method = getattr(self, 'format_%s' % key)
+                line = method(val)
+                lines.append(line + "\n")
+                break
+
+        return '\n'.join(lines)
+
+    def format_from(self, data):
+        return "FROM %s" % data
+
+    def format_run(self, data):
+        if isinstance(data, list):
+            text = ' \\\n && '.join(data)
+        else:
+            text = data
+
+        return "RUN %s" % text
+
+    def format_copy(self, data):
+        return 'COPY %s %s' % tuple(data)
+
+
+if __name__ == '__main__':
+    YamlToDockerfile.run(sys.argv[1:])

--- a/tool/docker/docbook-builder/Dockerfile.yaml
+++ b/tool/docker/docbook-builder/Dockerfile.yaml
@@ -1,0 +1,23 @@
+#!/usr/bin/env yaml-to-dockerfile
+
+- from: ubuntu:20.04
+
+- run:
+  - apt-get update
+  - DEBIAN_FRONTEND=noninteractive apt-get install -y
+      build-essential
+      default-jre
+      docbook-xsl
+      ghostscript
+      libexpat1-dev
+      libxml-parser-perl
+      libyaml-perl
+      xsltproc
+
+- run:
+    apt-get install -y
+      git
+      silversearcher-ag
+      tig
+      tmux
+      vim

--- a/tool/docker/docbook-builder/Makefile
+++ b/tool/docker/docbook-builder/Makefile
@@ -1,0 +1,7 @@
+include ../../make/init.mk
+
+include $(ROOT)/tool/make/init.mk
+
+include docker.mk
+
+include $(ROOT)/tool/make/docker.mk

--- a/tool/docker/docbook-builder/docker.mk
+++ b/tool/docker/docbook-builder/docker.mk
@@ -1,0 +1,2 @@
+DOCKER_IMAGE_NAME := yaml-spec-docbook-builder
+DOCKER_IMAGE_TAG := 0.0.1

--- a/tool/make/docker-run.mk
+++ b/tool/make/docker-run.mk
@@ -1,0 +1,20 @@
+ifndef DOCKER_IMAGE_NAME
+$(error DOCKER_IMAGE_NAME not set)
+endif
+
+DOCKER_IMAGE_ORG ?= yamlio
+DOCKER_IMAGE ?= $(DOCKER_IMAGE_ORG)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)
+
+IT :=
+ifdef TTY
+    IT := -it
+endif
+
+define docker-run
+docker run $(IT) --rm \
+    --volume $(ROOT):/host \
+    --workdir /host/$(CWD) \
+    $2 \
+    $(DOCKER_IMAGE) \
+    $1
+endef

--- a/tool/make/docker.mk
+++ b/tool/make/docker.mk
@@ -1,0 +1,16 @@
+DOCKER_DIR ?= .
+DOCKER_SHELL_CMD ?= tmux
+
+docker-build:
+	docker build \
+	    -t $(DOCKER_IMAGE) \
+	    -f $$(./Dockerfile.yaml) \
+	    $(DOCKER_DIR)
+
+docker-shell: docker-build
+	$(call docker-run,$(DOCKER_SHELL_CMD))
+
+docker-push: docker-build
+	docker push $(DOCKER_IMAGE)
+
+include $(ROOT)/tool/make/docker-run.mk

--- a/tool/make/init.mk
+++ b/tool/make/init.mk
@@ -1,0 +1,31 @@
+SHELL := bash
+
+ifeq ($(wildcard /.dockerenv),)
+ifndef YAML_SPEC_ROOT
+    $(info YAML_SPEC_ROOT is not set)
+    $(info Run 'source .rc' before using 'make' commands)
+    $(error Environment error)
+endif
+else
+    export YAML_SPEC_ROOT := /host
+endif
+
+ROOT := $(YAML_SPEC_ROOT)
+
+export PATH := $(ROOT)/tool/bin:$(PATH)
+
+pwd := $(shell dirname $(abspath $(firstword $(MAKEFILE_LIST))))
+CWD := $(pwd:$(ROOT)/%=%)
+
+TTY := $(shell [ -t 0 ] && echo 1)
+
+.DELETE_ON_ERROR:
+default:
+
+ifdef DOCKER_TOOL
+include $(ROOT)/tool/docker/$(DOCKER_TOOL)/docker.mk
+include $(ROOT)/tool/make/docker-run.mk
+
+docker-%:
+	make -C $(ROOT)/tool/docker/$(DOCKER_TOOL) $@
+endif


### PR DESCRIPTION
This should make it easy for anyone to build the spec.

The Makefile and Docker setup are general purpose and already in use on the
`spec-markdown` branch for the html-to-markdown process.

A GitHub actions test workflow has been added and is passing tests.

