### PR TITLE
Support external links at bottom of page

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -2,18 +2,18 @@
 
 **3rd Edition, Patched at 2009-10-01**
 
+{:.author-group}
 * **Oren Ben-Kiki <[oren@ben-kiki.org](mailto:oren@ben-kiki.org)>**
 * **Clark Evans <[cce@clarkevans.com](mailto:cce@clarkevans.com)>**
 * **Ingy döt Net <[ingy@ingy.net](mailto:ingy@ingy.net)>**
-{:.authorgroup}
 
 **Latest (patched) version:**
 
+{:.release-info}
 * HTML: [http://yaml.org/spec/1.2/spec.html](/spec/1.2/spec.html)
 * PDF: [http://yaml.org/spec/1.2/spec.pdf](/spec/1.2/spec.pdf)
 * PS: [http://yaml.org/spec/1.2/spec.ps](/spec/1.2/spec.ps)
 * Errata: [http://yaml.org/spec/1.2/errata.html](/spec/1.2/errata.html)
-{:.releaseinfo}
 
 **Previous (original) version:**
 [http://yaml.org/spec/1.2/2009-07-21/spec.html](/spec/1.2/2009-07-21/spec.html)
@@ -81,7 +81,8 @@ Version 1.2 and to create programs that process YAML information.
 
 **Contents**
 
-::toc
+{:toc}
+* TOC
 
 # Chapter #. Introduction
 
@@ -6230,3 +6231,7 @@ The yaml-core mailing list at
 <http://lists.sourceforge.net/lists/listinfo/yaml-core>
 is the preferred method for such submissions, as well as raising any questions
 regarding this draft.
+
+# Reference Links
+
+{:.footnote-links}

--- a/tool/bin/markydown-to-kramdown
+++ b/tool/bin/markydown-to-kramdown
@@ -9,6 +9,7 @@ use XXX;
 my ($YYYY, $MM, $DD);
 my (@lvl) = (0, 0, 0, 0);
 my $links = {};
+my @footnote_links;
 
 sub main {
   my ($front, $markdown, $link_map) = read_files(@_);
@@ -35,6 +36,7 @@ sub main {
 my $x = '(?s:.)';
 my $s = '\ ';
 my $line = '(?:.*\n)';
+my $line_not_blank = '(?:(?:.*\S.*\n)|\n(?=\ \ ))';
 my $comment = '(?s:<!--.*?-->\n)';
 my $li = '(?:\*\ \S.*\n)';
 my $b = '\*\*';
@@ -96,23 +98,13 @@ sub parse_sections {
     # Unordered list:
     s/\A
       (
-        (::$line)?
-        (?:
-          (?:$li)
-          (?:
-            (?:
-              \n
-              ($s$s\S$line)+
-            )+
-            \n?
-          )?
-          (?:$s$s\*$s$line)*
-        )+
+        $ial*
+        $li
+        $line_not_blank*
         $ial*
       )
       \n+
-    //x
-      and push @s, {ul => $1} and next;
+    //x and push @s, {ul => $1} and next;
 
     # Unordered list:
     s{\A
@@ -156,9 +148,6 @@ sub parse_sections {
     s/\A(----\n)\n+//
       and push @s, {hr => $1} and next;
 
-    s/\A\::toc\n\n+//
-      and push @s, {toc => 1} and next;
-
     s/\A((?s:```.+?\n```\n))\n+//
       and push @s, {pre => $1} and next;
 
@@ -176,6 +165,8 @@ sub parse_sections {
 
     s/\A($comment)\n*//
       and push @s, {comment => $1} and next;
+
+    s/\A$ial// and next;
 
     s/\n+\z// and next;
 
@@ -309,13 +300,16 @@ $out
 }
 
 sub fmt_ul {
-  undefined_links();
+  format_links();
+  if (/^\{:\.footnote-links\}$/m) {
+    format_footnotes();
+  }
 }
 
 my $figure = 0;
 sub fmt_p {
   set_dates();
-  undefined_links();
+  format_links();
   if (/^\*\*Figure #\./m) {
     my $chapter = $lvl[0];
     $figure++;
@@ -326,7 +320,7 @@ sub fmt_p {
 sub fmt_hr {}
 
 sub fmt_indent {
-  undefined_links();
+  format_links();
 }
 
 my $num = 0;
@@ -363,19 +357,6 @@ sub fmt_comment {}
 sub fmt_img {}
 
 sub fmt_table {}
-
-sub fmt_toc {
-  $_ = <<'...';
-* TOC
-{:toc}
-...
-}
-
-sub fmt_index {
-  $_ = <<'...';
-# Index
-...
-}
 
 #------------------------------------------------------------------------------
 sub read_files {
@@ -471,7 +452,25 @@ sub rule_link {
   return qq{<a href="#rule-$rule">$text<\/a>};
 }
 
-sub get_link {
+sub format_links {
+  s{
+    \[
+      ( [^\]]*? ) \^
+    \]
+  }{format_footnote_link($1)}gex;
+
+  s{
+    \[
+      (
+        [^-0-9\`\]]
+        [^\]]*?
+      )
+    \]
+    (?= [^\(\`] )
+  }{format_internal_link($1)}gex;
+}
+
+sub format_internal_link {
   my ($link) = @_;
   my $text = lc($link);
   $text =~ s/\s+/ /g;
@@ -489,8 +488,14 @@ sub get_link {
   return "~~[$link](#undefined)~~";
 }
 
-sub undefined_links {
-  s/\[([^-0-9\`\]][^\]]*?)\](?=[^\(\`])/get_link($1)/sge;
+sub format_footnote_link {
+  my ($text) = @_;
+  $text =~ s/\s+/ /g;
+  die "Duplicate external link text not supported yet '$text'"
+    if grep { $_ eq $text } @footnote_links;
+  push @footnote_links, $text;
+  my $i = @footnote_links;
+  return qq{<span class="footnote-link">$text<sup id="fnl$i">[$i](#fn$i)</sup></span>};
 }
 
 sub set_dates {
@@ -630,6 +635,47 @@ sub format_legend {
   $_ = join "\n", @lines;
   s{\[([^\]]+)\]}{rule_link($1)}ge;
   return $_;
+}
+
+sub format_footnotes {
+  my $footnote_map = parse_footnote_section();
+
+  $_ = qq{<ol class="footnote-links">\n};
+
+  my $i = 1;
+  for my $footnote_link (@footnote_links) {
+    my $entry = $footnote_map->{$footnote_link} or
+      die "No footnote-links entry for '$footnote_link'";
+    my ($text, $link) = @$entry;
+    $_ .= qq{<li id="fn$i" markdown="1">\n};
+    $_ .= qq{<a href="$link" target="_blank">"$text"</a> [↩](#fnl$i)\n};
+    $_ .= qq{</li>\n};
+    $i++;
+  }
+
+  $_ .= qq{</ol>\n};
+  $_ .= qq{<div class="footnote-links-after" />\n};
+}
+
+sub parse_footnote_section {
+  my $footnote_map = {};
+  while ($_) {
+    s/\{.*\}\n// and next;
+    s/\A\*\ (.*)\n// or die $_;
+    my $label = $1;
+    s/\A
+      \ \ \*\ \[
+        ( [^\]]* )
+      \]
+      \(
+        (?:\n?\ +)?
+        ( [^\)]* )
+      \)
+      \n
+    //x or die $_;
+    $footnote_map->{$label} = [ $1, $2 ];
+  }
+  return $footnote_map;
 }
 
 main @ARGV;

--- a/www/spec.scss
+++ b/www/spec.scss
@@ -1,6 +1,8 @@
+$theme-color: #606c71;
+
 a[href^="#"] {
   color: inherit;
-  text-decoration: underline solid #606c71;
+  text-decoration: underline solid $theme-color;
 
   &:hover {
     color: blue;
@@ -45,7 +47,6 @@ pre.example {
 }
 
 .main-content blockquote {
-  color: #000;
   margin-right: 0px;
   border-left: none;
 }
@@ -99,9 +100,28 @@ div.legend {
   }
 }
 
-ul.authorgroup,
-ul.releaseinfo,
+ul.author-group,
+ul.release-info,
 #markdown-toc,
 #markdown-toc ul {
   list-style: none;
+}
+
+span.footnote-link {
+  text-decoration: underline solid $theme-color;
+
+  sup a {
+    color: blue;
+    text-decoration: none;
+  }
+}
+
+.footnote-links {
+  p {
+    margin-bottom: 0px;
+  }
+}
+
+.footnote-links-after {
+  height: 1000px;
 }


### PR DESCRIPTION
The markydown `[link text^]` will format an external link at the bottom
of the page like wikipedia does.

At the bottom you need a section like:
```
{:.footnote-links}
* link text
  * [Linked page title text](http://external.link)
```

Each link must have an entry below, but the order of rendering is the
order of links, not the list below.
