### PR TITLE
Cyclic node equality implementation defined

### DIFF
--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -981,8 +981,8 @@ scheme.
 [Tags] in a YAML stream must therefore be [presented] in a canonical way so
 that such comparison would yield the correct results.
 
-> If a node has itself as a descendant (via an alias), then equality of that node
-is implementation-defined.
+> If a node has itself as a descendant (via an alias), then determining the
+equality of that node is implementation-defined.
 
 : A YAML [processor] may treat equal [scalars] as if they were identical.
 

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -981,6 +981,9 @@ scheme.
 [Tags] in a YAML stream must therefore be [presented] in a canonical way so
 that such comparison would yield the correct results.
 
+> If a node has itself as a descendant (via an alias), then equality of that node
+is implementation-defined.
+
 : A YAML [processor] may treat equal [scalars] as if they were identical.
 
 

--- a/spec/1.2/spec.md
+++ b/spec/1.2/spec.md
@@ -1126,9 +1126,6 @@ scheme.
 [Tags] in a YAML stream must therefore be [presented] in a canonical way so
 that such comparison would yield the correct results.
 
-> If a node has itself as a descendant (via an alias), then equality of that node
-is implementation-defined.
-
 
 ##### Identity
 

--- a/spec/1.2/spec.md
+++ b/spec/1.2/spec.md
@@ -1116,9 +1116,6 @@ Two [mappings] are equal only when they have the same [tag] and an equal set
 of [keys], and each [key] in this set is associated with equal [values] in
 both [mappings].
 
-If a node has itself as a descendant (via an alias), then equality of that node
-is implementation-defined.
-
 > Different URI schemes may define different rules for testing the equality of
 URIs.
 Since a YAML [processor] cannot be reasonably expected to be aware of them
@@ -1128,6 +1125,9 @@ This also happens to be the comparison method defined by the "**`tag:`**" URI
 scheme.
 [Tags] in a YAML stream must therefore be [presented] in a canonical way so
 that such comparison would yield the correct results.
+
+> If a node has itself as a descendant (via an alias), then equality of that node
+is implementation-defined.
 
 
 ##### Identity

--- a/spec/1.2/spec.md
+++ b/spec/1.2/spec.md
@@ -1116,6 +1116,9 @@ Two [mappings] are equal only when they have the same [tag] and an equal set
 of [keys], and each [key] in this set is associated with equal [values] in
 both [mappings].
 
+If a node has itself as a descendant (via an alias), then equality of that node
+is implementation-defined.
+
 > Different URI schemes may define different rules for testing the equality of
 URIs.
 Since a YAML [processor] cannot be reasonably expected to be aware of them


### PR DESCRIPTION
For #36.

It might be over-cautious to say that equality of *all* cyclic nodes is implementation-defined, but off the top of my head I can't think of a tighter criterion that's easy to understand.