### PR TITLE
Latex png cleanup

### DIFF
--- a/spec/tex/include/head.tex
+++ b/spec/tex/include/head.tex
@@ -6,27 +6,23 @@
 
 \newcommand{\entity}[3][]{
   \node(#2)[
-    \ifstrempty{#3}{entity}{entityAttrs},
+    entity,
     #1
   ] {
-    \textbf {#2}
-    \ifstrempty{#3}{}{
-      \nodepart[align=left]{second} #3
-    }
+    \nodepart[font=\bfseries]{one} #2
+    \nodepart{two} #3
   };
 }
 
 \tikzset{
   entity/.style = {
     draw,
-    rectangle,
-    % anchor=north,
-    minimum width=3cm,
-  },
-  entityAttrs/.style = {
-    entity,
+    align=left,
     rectangle split,
     rectangle split parts=2,
+    rectangle split ignore empty parts,
+    rectangle split part align={center, left},
+    minimum width=3cm,
   },
   parallellogram/.style = {
     draw,
@@ -43,6 +39,11 @@
   },
   inherits/.style = {
     -{Latex[open, length=3mm]},
+  },
+  bigArrow/.style = {
+    -{Latex[length=5mm]},
+    line width=1mm,
+    font=\bfseries,
   },
   node distance=2cm and 1cm,
 }

--- a/spec/tex/include/head.tex
+++ b/spec/tex/include/head.tex
@@ -5,46 +5,46 @@
 \renewcommand{\familydefault}{\sfdefault}
 
 \newcommand{\entity}[3][]{
-    \node(#2)[
-        \ifstrempty{#3}{entity}{entityAttrs},
-        #1
-    ] {
-        \textbf {#2}
-        \ifstrempty{#3}{}{
-            \nodepart[align=left]{second} #3
-        }
-    };
+  \node(#2)[
+    \ifstrempty{#3}{entity}{entityAttrs},
+    #1
+  ] {
+    \textbf {#2}
+    \ifstrempty{#3}{}{
+      \nodepart[align=left]{second} #3
+    }
+  };
 }
 
 \tikzset{
-    entity/.style = {
-        draw,
-        rectangle,
-        % anchor=north,
-        minimum width=3cm,
-    },
-    entityAttrs/.style = {
-        entity,
-        rectangle split,
-        rectangle split parts=2,
-    },
-    parallellogram/.style = {
-        draw,
-        trapezium,
-        trapezium left angle=75,
-        trapezium right angle=105,
-    },
-    onArrow/.style = {
-        fill=white,
-        align=center,
-    },
-    has/.style = {
-        -{Latex[length=3mm]},
-    },
-    inherits/.style = {
-        -{Latex[open, length=3mm]},
-    },
-    node distance=2cm and 1cm,
+  entity/.style = {
+    draw,
+    rectangle,
+    % anchor=north,
+    minimum width=3cm,
+  },
+  entityAttrs/.style = {
+    entity,
+    rectangle split,
+    rectangle split parts=2,
+  },
+  parallellogram/.style = {
+    draw,
+    trapezium,
+    trapezium left angle=75,
+    trapezium right angle=105,
+  },
+  onArrow/.style = {
+    fill=white,
+    align=center,
+  },
+  has/.style = {
+    -{Latex[length=3mm]},
+  },
+  inherits/.style = {
+    -{Latex[open, length=3mm]},
+  },
+  node distance=2cm and 1cm,
 }
 
 % Attempt to get a little border padding

--- a/spec/tex/model2.tex
+++ b/spec/tex/model2.tex
@@ -7,15 +7,15 @@
 \begin{tikzpicture}
 
 \entity{Node}{
-    +Anchor\\
-    ++Style, Spacing,\\
-    Line Wrapping…
+  +Anchor\\
+  ++Style, Spacing,\\
+  Line Wrapping…
 };
 
 \entity[above=of Node]{Tag}{Name\\Kind};
 \draw[has] (Node) -- (Tag)
-    node[near start, right]{1}
-    node[near end, right]{*};
+  node[near start, right]{1}
+  node[near end, right]{*};
 
 \entity[right=of Tag]{Scalar Tag}{Canonical Format};
 \draw[inherits] (Scalar Tag) -- (Tag);
@@ -28,23 +28,23 @@
 
 \node[parallellogram, below=of Scalar Node](Canonical Content) {String};
 \draw[has] (Scalar Node) -- (Canonical Content)
-    node[onArrow, midway] {Canonical\\/ ++ Formatted\\Content};
+  node[onArrow, midway] {Canonical\\/ ++ Formatted\\Content};
 
 \entity[left=of Scalar Node]{Sequence Node}{};
 \draw[inherits] (Sequence Node) -- ++(0,+10mm) -| (Node);
 
 \draw[has] (Sequence Node.west)
-    -- ++(-5mm, 0) node[near start, below] {*}
-    |- (Node) node[onArrow, pos=0.25] {Ordered\\Content}
-    node[at end, above left] {*};
+  -- ++(-5mm, 0) node[near start, below] {*}
+  |- (Node) node[onArrow, pos=0.25] {Ordered\\Content}
+  node[at end, above left] {*};
 
 \entity[below=of Sequence Node]{+ Alias Node}{};
 \draw[inherits]
-    let
-        \p1 = ($(+ Alias Node.east)+(5mm,0)$),
-        \p2 = ($(Sequence Node)+(0,10mm)$)
-    in
-    (+ Alias Node) -| (\x1,\y2) -| (Node)
+  let
+    \p1 = ($(+ Alias Node.east)+(5mm,0)$),
+    \p2 = ($(Sequence Node)+(0,10mm)$),
+  in
+  (+ Alias Node) -| (\x1,\y2) -| (Node)
 ;
 
 \entity[right=of Scalar Node]{Mapping Node}{};
@@ -53,33 +53,33 @@
 \entity[right=of Node]{Key/Value Pair}{};
 
 \draw[has]
-    (Mapping Node.east)
-    -- ++(10mm, 0) node[near start, below] {*}
-    |- (Key/Value Pair) node[onArrow, pos=0.25] {Unordered\\/ + Ordered\\Content}
-    node[at end, above right] {*};
+  (Mapping Node.east)
+  -- ++(10mm, 0) node[near start, below] {*}
+  |- (Key/Value Pair) node[onArrow, pos=0.25] {Unordered\\/ + Ordered\\Content}
+  node[at end, above right] {*};
 
 \draw[has] (Key/Value Pair.north)
-    |- ($(Node.north)+(0.5,0.5)$)
-    node[at start, above right] {1}
-    node[pos=0.75, onArrow] {Key}
-    -- ($(Node.north)+(0.5,0)$)
-    node[at start, above right] {*};
+  |- ($(Node.north)+(0.5,0.5)$)
+  node[at start, above right] {1}
+  node[pos=0.75, onArrow] {Key}
+  -- ($(Node.north)+(0.5,0)$)
+  node[at start, above right] {*};
 
 \draw[has] (Key/Value Pair.south)
-    |- ($(Node.south)+(0.5,-0.5)$)
-    node[at start, below right] {1}
-    node[pos=0.75, onArrow] {Value}
-    -- ($(Node.south)+(0.5,0)$)
-    node[at start, below right] {*};
+  |- ($(Node.south)+(0.5,-0.5)$)
+  node[at start, below right] {1}
+  node[pos=0.75, onArrow] {Value}
+  -- ($(Node.south)+(0.5,0)$)
+  node[at start, below right] {*};
 
 \entity[below=of Mapping Node]{++ Comment}{}
 
 \entity[above left=of Node]{++ Directive}{Name\\Parameters}
 
 \entity[above left=of Tag]{Legend}{
-    YAML Representation\\
-    + YAML Serialization\\
-    ++ YAML Presentation
+  YAML Representation\\
+  + YAML Serialization\\
+  ++ YAML Presentation
 }
 
 \end{tikzpicture}

--- a/spec/tex/overview2.tex
+++ b/spec/tex/overview2.tex
@@ -5,54 +5,54 @@
 \begin{document}
 
 \begin{tikzpicture}[
-    process/.style = {
-        -{Latex[length=3mm]},
-        out=45,
-        in=135,
-        relative,
-        line width=.5mm,
-    },
-    bigArrow/.style = {
-        -{Latex[length=5mm]},
-        line width=1mm,
-    },
-    stage/.style = {
-        entityAttrs,
-        align=center,
-        minimum width=4cm,
-    },
-    node distance=2.0cm
+  process/.style = {
+    -{Latex[length=3mm]},
+    out=45,
+    in=135,
+    relative,
+    line width=.5mm,
+  },
+  bigArrow/.style = {
+    -{Latex[length=5mm]},
+    line width=1mm,
+  },
+  stage/.style = {
+    entityAttrs,
+    align=center,
+    minimum width=4cm,
+  },
+  node distance=2.0cm
 ]
 \node(Native)[stage] {
-    \textbf {Native}\\\textbf {(Data Structures)}
-    \nodepart[align=center]{second}
-        opaque\\
-        program\\
-        data
+  \textbf {Native}\\\textbf {(Data Structures)}
+  \nodepart[align=center]{second}
+    opaque\\
+    program\\
+    data
 };
 
 \node(Representation)[stage, right=of Native] {
-    \textbf {Representation}\\\textbf {(Node Graph)}
-    \nodepart[align=center]{second}
-        tags,\\
-        mapping/sequence/scalar,\\
-        canonical string values
+  \textbf {Representation}\\\textbf {(Node Graph)}
+  \nodepart[align=center]{second}
+    tags,\\
+    mapping/sequence/scalar,\\
+    canonical string values
 };
 
 \node(Serialization)[stage, right=of Representation] {
-    \textbf {Serialization}\\\textbf {(Event Tree)}
-    \nodepart[align=center]{second}
-        anchors,\\
-        aliases,\\
-        key order
+  \textbf {Serialization}\\\textbf {(Event Tree)}
+  \nodepart[align=center]{second}
+    anchors,\\
+    aliases,\\
+    key order
 };
 
 \node(Presentation)[stage, right=of Serialization] {
-    \textbf {Presentation}\\\textbf {(Character Stream)}
-    \nodepart[align=center]{second}
-        styles, comments,\\
-        directives, spacing,\\
-        formatted string values, …
+  \textbf {Presentation}\\\textbf {(Character Stream)}
+  \nodepart[align=center]{second}
+    styles, comments,\\
+    directives, spacing,\\
+    formatted string values, …
 };
 
 \coordinate (Divider) at ($(Native.east)!.5!(Representation.west)$);
@@ -61,9 +61,9 @@
 
 \draw
 let
-    \p1 = (Divider),
-    \p2 = (Native.north),
-    \p3 = ($(\x1,\y2)+(0,2.5)$),
+  \p1 = (Divider),
+  \p2 = (Native.north),
+  \p3 = ($(\x1,\y2)+(0,2.5)$),
 in
 node[left=.5cm] at (\p3) {\textbf {Application}}
 node[right=.5cm] at (\p3) {\textbf {YAML}};
@@ -76,9 +76,9 @@ node[right=.5cm] at (\p3) {\textbf {YAML}};
 \draw[process] (Presentation) edge node[onArrow] {Parse} (Serialization);
 
 \draw[bigArrow] ($(Native.north)+(0,2)$)
-    -- node[onArrow] {\textbf {Dump}} ($(Presentation.north)+(0,2)$);
+  -- node[onArrow] {\textbf {Dump}} ($(Presentation.north)+(0,2)$);
 \draw[bigArrow] ($(Presentation.south)+(0,-2)$)
-    -- node[onArrow] {\textbf {Load}} ($(Native.south)+(0,-2)$);
+  -- node[onArrow] {\textbf {Load}} ($(Native.south)+(0,-2)$);
 
 \end{tikzpicture}
 

--- a/spec/tex/overview2.tex
+++ b/spec/tex/overview2.tex
@@ -12,44 +12,46 @@
     relative,
     line width=.5mm,
   },
-  bigArrow/.style = {
-    -{Latex[length=5mm]},
-    line width=1mm,
-  },
   stage/.style = {
-    entityAttrs,
+    entity,
     align=center,
+    rectangle split part align={center},
     minimum width=4cm,
+    align=center,
   },
   node distance=2.0cm
 ]
 \node(Native)[stage] {
-  \textbf {Native}\\\textbf {(Data Structures)}
-  \nodepart[align=center]{second}
+  \nodepart[font=\bfseries]{one}
+  Native\\(Data Structures)
+  \nodepart{two}
     opaque\\
     program\\
     data
 };
 
 \node(Representation)[stage, right=of Native] {
-  \textbf {Representation}\\\textbf {(Node Graph)}
-  \nodepart[align=center]{second}
+  \nodepart[font=\bfseries]{one}
+  Representation\\(Node Graph)
+  \nodepart{two}
     tags,\\
     mapping/sequence/scalar,\\
     canonical string values
 };
 
 \node(Serialization)[stage, right=of Representation] {
-  \textbf {Serialization}\\\textbf {(Event Tree)}
-  \nodepart[align=center]{second}
+  \nodepart[font=\bfseries]{one}
+  Serialization\\(Event Tree)
+  \nodepart{two}
     anchors,\\
     aliases,\\
     key order
 };
 
 \node(Presentation)[stage, right=of Serialization] {
-  \textbf {Presentation}\\\textbf {(Character Stream)}
-  \nodepart[align=center]{second}
+  \nodepart[font=\bfseries]{one}
+  Presentation\\(Character Stream)
+  \nodepart{two}
     styles, comments,\\
     directives, spacing,\\
     formatted string values, …
@@ -76,9 +78,9 @@ node[right=.5cm] at (\p3) {\textbf {YAML}};
 \draw[process] (Presentation) edge node[onArrow] {Parse} (Serialization);
 
 \draw[bigArrow] ($(Native.north)+(0,2)$)
-  -- node[onArrow] {\textbf {Dump}} ($(Presentation.north)+(0,2)$);
+  -- node[onArrow] {Dump} ($(Presentation.north)+(0,2)$);
 \draw[bigArrow] ($(Presentation.south)+(0,-2)$)
-  -- node[onArrow] {\textbf {Load}} ($(Native.south)+(0,-2)$);
+  -- node[onArrow] {Load} ($(Native.south)+(0,-2)$);
 
 \end{tikzpicture}
 

--- a/spec/tex/present2.tex
+++ b/spec/tex/present2.tex
@@ -7,15 +7,15 @@
 \begin{tikzpicture}
 
 \entity{Node}{
-    +Anchor\\
-    ++Style, Spacing,\\
-    Line Wrapping…
+  +Anchor\\
+  ++Style, Spacing,\\
+  Line Wrapping…
 };
 
 \entity[above=of Node]{Tag}{Name\\Kind};
 \draw[has] (Node) -- (Tag)
-    node[near start, right]{1}
-    node[near end, right]{*};
+  node[near start, right]{1}
+  node[near end, right]{*};
 
 \entity[right=of Tag]{++ Non-Specific Tag}{};
 \draw[inherits] (++ Non-Specific Tag) -- (Tag);
@@ -25,23 +25,23 @@
 
 \node[parallellogram, below=of Scalar Node](Canonical Content) {String};
 \draw[has] (Scalar Node) -- (Canonical Content)
-    node[onArrow, midway] {++ Formatted\\Content};
+  node[onArrow, midway] {++ Formatted\\Content};
 
 \entity[left=of Scalar Node]{Sequence Node}{};
 \draw[inherits] (Sequence Node) -- ++(0,+10mm) -| (Node);
 
 \draw[has] (Sequence Node.west)
-    -- ++(-5mm, 0) node[near start, below] {*}
-    |- (Node) node[onArrow, pos=0.25] {Ordered\\Content}
-    node[at end, above left] {*};
+  -- ++(-5mm, 0) node[near start, below] {*}
+  |- (Node) node[onArrow, pos=0.25] {Ordered\\Content}
+  node[at end, above left] {*};
 
 \entity[below=of Sequence Node]{+ Alias Node}{};
 \draw[inherits]
-    let
-        \p1 = ($(+ Alias Node.east)+(5mm,0)$),
-        \p2 = ($(Sequence Node)+(0,10mm)$)
-    in
-    (+ Alias Node) -| (\x1,\y2) -| (Node)
+  let
+    \p1 = ($(+ Alias Node.east)+(5mm,0)$),
+    \p2 = ($(Sequence Node)+(0,10mm)$)
+  in
+  (+ Alias Node) -| (\x1,\y2) -| (Node)
 ;
 
 \entity[right=of Scalar Node]{Mapping Node}{};
@@ -50,33 +50,33 @@
 \entity[right=of Node]{Key/Value Pair}{};
 
 \draw[has]
-    (Mapping Node.east)
-    -- ++(10mm, 0) node[near start, below] {*}
-    |- (Key/Value Pair) node[onArrow, pos=0.25] {+ Ordered\\Content}
-    node[at end, above right] {*};
+  (Mapping Node.east)
+  -- ++(10mm, 0) node[near start, below] {*}
+  |- (Key/Value Pair) node[onArrow, pos=0.25] {+ Ordered\\Content}
+  node[at end, above right] {*};
 
 \draw[has] (Key/Value Pair.north)
-    |- ($(Node.north)+(0.5,0.5)$)
-    node[at start, above right] {1}
-    node[pos=0.75, onArrow] {Key}
-    -- ($(Node.north)+(0.5,0)$)
-    node[at start, above right] {*};
+  |- ($(Node.north)+(0.5,0.5)$)
+  node[at start, above right] {1}
+  node[pos=0.75, onArrow] {Key}
+  -- ($(Node.north)+(0.5,0)$)
+  node[at start, above right] {*};
 
 \draw[has] (Key/Value Pair.south)
-    |- ($(Node.south)+(0.5,-0.5)$)
-    node[at start, below right] {1}
-    node[pos=0.75, onArrow] {Value}
-    -- ($(Node.south)+(0.5,0)$)
-    node[at start, below right] {*};
+  |- ($(Node.south)+(0.5,-0.5)$)
+  node[at start, below right] {1}
+  node[pos=0.75, onArrow] {Value}
+  -- ($(Node.south)+(0.5,0)$)
+  node[at start, below right] {*};
 
 \entity[below=of Mapping Node]{++ Comment}{}
 
 \entity[above left=of Node]{++ Directive}{Name\\Parameters}
 
 \entity[above left=of Tag]{Legend}{
-    YAML Representation\\
-    + YAML Serialization\\
-    \textbf {++ YAML Presentation}
+  YAML Representation\\
+  + YAML Serialization\\
+  \textbf {++ YAML Presentation}
 }
 
 \end{tikzpicture}

--- a/spec/tex/represent2.tex
+++ b/spec/tex/represent2.tex
@@ -10,8 +10,8 @@
 
 \entity[above=of Node]{Tag}{Name\\Kind};
 \draw[has] (Node) -- (Tag)
-    node[near start, right]{1}
-    node[near end, right]{*};
+  node[near start, right]{1}
+  node[near end, right]{*};
 
 \entity[right=of Tag]{Scalar Tag}{Canonical Format};
 \draw[inherits] (Scalar Tag) -- (Tag);
@@ -21,15 +21,15 @@
 
 \node[parallellogram, below=of Scalar Node](Canonical Content) {String};
 \draw[has] (Scalar Node) -- (Canonical Content)
-    node[onArrow, midway] {Canonical\\Content};
+  node[onArrow, midway] {Canonical\\Content};
 
 \entity[left=of Scalar Node]{Sequence Node}{};
 \draw[inherits] (Sequence Node) -- ++(0,+10mm) -| (Node);
 
 \draw[has] (Sequence Node.west)
-    -- ++(-5mm, 0) node[near start, below] {*}
-    |- (Node) node[onArrow, pos=0.25] {Ordered\\Content}
-    node[at end, above left] {*};
+  -- ++(-5mm, 0) node[near start, below] {*}
+  |- (Node) node[onArrow, pos=0.25] {Ordered\\Content}
+  node[at end, above left] {*};
 
 \entity[right=of Scalar Node]{Mapping Node}{};
 \draw[inherits] (Mapping Node) -- ++(0,+10mm) -| (Node);
@@ -37,24 +37,24 @@
 \entity[right=of Node]{Key/Value Pair}{};
 
 \draw[has]
-    (Mapping Node.east)
-    -- ++(5mm, 0) node[near start, below] {*}
-    |- (Key/Value Pair) node[onArrow, pos=0.25] {Unordered\\Content}
-    node[at end, above right] {*};
+  (Mapping Node.east)
+  -- ++(5mm, 0) node[near start, below] {*}
+  |- (Key/Value Pair) node[onArrow, pos=0.25] {Unordered\\Content}
+  node[at end, above right] {*};
 
 \draw[has] (Key/Value Pair.north)
-    |- ($(Node.north)+(0.5,0.5)$)
-    node[at start, above right] {1}
-    node[pos=0.75, onArrow] {Key}
-    -- ($(Node.north)+(0.5,0)$)
-    node[at start, above right] {*};
+  |- ($(Node.north)+(0.5,0.5)$)
+  node[at start, above right] {1}
+  node[pos=0.75, onArrow] {Key}
+  -- ($(Node.north)+(0.5,0)$)
+  node[at start, above right] {*};
 
 \draw[has] (Key/Value Pair.south)
-    |- ($(Node.south)+(0.5,-0.5)$)
-    node[at start, below right] {1}
-    node[pos=0.75, onArrow] {Value}
-    -- ($(Node.south)+(0.5,0)$)
-    node[at start, below right] {*};
+  |- ($(Node.south)+(0.5,-0.5)$)
+  node[at start, below right] {1}
+  node[pos=0.75, onArrow] {Value}
+  -- ($(Node.south)+(0.5,0)$)
+  node[at start, below right] {*};
 
 \end{tikzpicture}
 

--- a/spec/tex/serialize2.tex
+++ b/spec/tex/serialize2.tex
@@ -7,13 +7,13 @@
 \begin{tikzpicture}
 
 \entity{Node}{
-    +Anchor
+  +Anchor
 };
 
 \entity[above=of Node]{Tag}{Name\\Kind};
 \draw[has] (Node) -- (Tag)
-    node[near start, right]{1}
-    node[near end, right]{*};
+  node[near start, right]{1}
+  node[near end, right]{*};
 
 \entity[right=of Tag]{Scalar Tag}{Canonical Format};
 \draw[inherits] (Scalar Tag) -- (Tag);
@@ -23,23 +23,23 @@
 
 \node[parallellogram, below=of Scalar Node](Canonical Content) {String};
 \draw[has] (Scalar Node) -- (Canonical Content)
-    node[onArrow, midway] {Canonical\\Content};
+  node[onArrow, midway] {Canonical\\Content};
 
 \entity[left=of Scalar Node]{Sequence Node}{};
 \draw[inherits] (Sequence Node) -- ++(0,+10mm) -| (Node);
 
 \draw[has] (Sequence Node.west)
-    -- ++(-5mm, 0) node[near start, below] {*}
-    |- (Node) node[onArrow, pos=0.25] {Ordered\\Content}
-    node[at end, above left] {*};
+  -- ++(-5mm, 0) node[near start, below] {*}
+  |- (Node) node[onArrow, pos=0.25] {Ordered\\Content}
+  node[at end, above left] {*};
 
 \entity[below=of Sequence Node]{+ Alias Node}{};
 \draw[inherits]
-    let
-        \p1 = ($(+ Alias Node.east)+(5mm,0)$),
-        \p2 = ($(Sequence Node)+(0,10mm)$)
-    in
-    (+ Alias Node) -| (\x1,\y2) -| (Node)
+  let
+    \p1 = ($(+ Alias Node.east)+(5mm,0)$),
+    \p2 = ($(Sequence Node)+(0,10mm)$)
+  in
+  (+ Alias Node) -| (\x1,\y2) -| (Node)
 ;
 
 \entity[right=of Scalar Node]{Mapping Node}{};
@@ -48,28 +48,28 @@
 \entity[right=of Node]{Key/Value Pair}{};
 
 \draw[has]
-    (Mapping Node.east)
-    -- ++(10mm, 0) node[near start, below] {*}
-    |- (Key/Value Pair) node[onArrow, pos=0.25] {Ordered\\Content}
-    node[at end, above right] {*};
+  (Mapping Node.east)
+  -- ++(10mm, 0) node[near start, below] {*}
+  |- (Key/Value Pair) node[onArrow, pos=0.25] {Ordered\\Content}
+  node[at end, above right] {*};
 
 \draw[has] (Key/Value Pair.north)
-    |- ($(Node.north)+(0.5,0.5)$)
-    node[at start, above right] {1}
-    node[pos=0.75, onArrow] {Key}
-    -- ($(Node.north)+(0.5,0)$)
-    node[at start, above right] {*};
+  |- ($(Node.north)+(0.5,0.5)$)
+  node[at start, above right] {1}
+  node[pos=0.75, onArrow] {Key}
+  -- ($(Node.north)+(0.5,0)$)
+  node[at start, above right] {*};
 
 \draw[has] (Key/Value Pair.south)
-    |- ($(Node.south)+(0.5,-0.5)$)
-    node[at start, below right] {1}
-    node[pos=0.75, onArrow] {Value}
-    -- ($(Node.south)+(0.5,0)$)
-    node[at start, below right] {*};
+  |- ($(Node.south)+(0.5,-0.5)$)
+  node[at start, below right] {1}
+  node[pos=0.75, onArrow] {Value}
+  -- ($(Node.south)+(0.5,0)$)
+  node[at start, below right] {*};
 
 \entity[left=of Tag]{Legend}{
-    YAML Representation\\
-    \textbf {+ YAML Serialization}
+  YAML Representation\\
+  \textbf {+ YAML Serialization}
 }
 
 \end{tikzpicture}

--- a/spec/tex/styles2.tex
+++ b/spec/tex/styles2.tex
@@ -4,9 +4,9 @@
 \input{tex/include/head}
 
 \newcommand{\dotbox}[1]{
-    \begin{tikzpicture}[solid]
-    #1
-    \end{tikzpicture}
+  \begin{tikzpicture}[solid]
+  #1
+  \end{tikzpicture}
 }
 
 \begin{document}
@@ -39,7 +39,6 @@
   },
   column 1/.style = {nodes={minimum width=4cm}},
 ] {
-
   \dotbox{
     \node(Double)[rounded] at (0,0) {Double};
     \node(Single)[rounded] at (2,0) {Single};

--- a/spec/tex/validity2.tex
+++ b/spec/tex/validity2.tex
@@ -4,71 +4,71 @@
 \begin{document}
 
 \begin{tikzpicture}[
-    rect/.style = {
-        draw,
-        rectangle,
-        align=center,
-        minimum width=3.5cm,
-        minimum height=1.5cm,
-    },
-    hex/.style = {
-        rect,
-        signal,
-        signal to={west and east},
-        signal pointer angle=120,
-    },
-    rounded/.style = {
-        rect,
-        rounded rectangle,
-    },
-    decision/.style = {
-        draw,
-        circle,
-        node contents=?,
-    },
-    goes/.style = {
-        -{Latex[length=3mm]},
-    },
-    bigArrow/.style = {
-        -{Latex[length=5mm]},
-        line width=1mm,
-    },
+  rect/.style = {
+    draw,
+    rectangle,
+    align=center,
+    minimum width=3.5cm,
+    minimum height=1.5cm,
+  },
+  hex/.style = {
+    rect,
+    signal,
+    signal to={west and east},
+    signal pointer angle=120,
+  },
+  rounded/.style = {
+    rect,
+    rounded rectangle,
+  },
+  decision/.style = {
+    draw,
+    circle,
+    node contents=?,
+  },
+  goes/.style = {
+    -{Latex[length=3mm]},
+  },
+  bigArrow/.style = {
+    -{Latex[length=5mm]},
+    line width=1mm,
+  },
 ]
 
 \matrix[
-    row sep=.5cm,
-    column sep=.75cm,
+  row sep=.5cm,
+  column sep=.75cm,
 ] {
-    \node(Start) {
-        \begin{tikzpicture}[solid]
-        \draw (.5,0) arc (0:360:.5);
-        \foreach \angle in { 0, 45,..., 360 }{
-            \draw [rotate around={\angle:(0,0)}]
-                (.55,0) -- +(0,-.15) -- +(.3,0) -- +(0,.15) -- cycle;
-        };
-        \end{tikzpicture}
-    }; \\
+  \node(Start) {
+    \begin{tikzpicture}[solid]
+    \draw (.5,0) arc (0:360:.5);
+    \foreach \angle in { 0, 45,..., 360 }{
+      \draw [rotate around={\angle:(0,0)}]
+        (.55,0) -- +(0,-.15) -- +(.3,0) -- +(0,.15) -- cycle;
+    };
+    \end{tikzpicture}
+  }; \\
 
-    \node(Q1)[decision]; \\
-    \node(Well)[rect] {Well Formed\\and Identified}; &
-    \node(Ill)[hex] {Ill Formed\\or Unidentified}; &
-    \node(No)[rounded] {No\\Representation}; \\
+  \node(Q1)[decision]; \\
+  \node(Well)[rect] {Well Formed\\and Identified}; &
+  \node(Ill)[hex] {Ill Formed\\or Unidentified}; &
+  \node(No)[rounded] {No\\Representation}; \\
 
-    \node(Q2)[decision]; \\
-    \node(Resolved)[rect] {Resolved}; &
-    \node(Unresolved)[hex] {Unresolved}; &
-    \node(Partial)[rounded] {Partial\\Representation}; \\
+  \node(Q2)[decision]; \\
+  \node(Resolved)[rect] {Resolved}; &
+  \node(Unresolved)[hex] {Unresolved}; &
+  \node(Partial)[rounded] {Partial\\Representation}; \\
 
-    \node(Q3)[decision]; \\
-    \node(Recognized)[rect] {Recognized\\and Valid}; &
-    \node(Unrecognized)[hex] {Unrecognized\\or Invalid};\\
+  \node(Q3)[decision]; \\
+  \node(Recognized)[rect] {Recognized\\and Valid}; &
+  \node(Unrecognized)[hex] {Unrecognized\\or Invalid};\\
 
-    \node(Q4)[decision]; \\
-    \node(Available)[rect] {Available}; &
-    \node(Unavailable)[hex] {Unavailable}; &
-    \node(Complete)[rounded] {Complete\\Representation}; \\[1cm]
+  \node(Q4)[decision]; \\
+  \node(Available)[rect] {Available}; &
+  \node(Unavailable)[hex] {Unavailable}; &
+  \node(Complete)[rounded] {Complete\\Representation}; \\[1cm]
 
-    & & \node(Native)[rounded] {Construct\\Native Data}; \\
+  & & \node(Native)[rounded] {Construct\\Native Data}; \\
 };
 
 \draw[goes] (Start) -- (Q1);
@@ -94,15 +94,15 @@
 \draw[goes] (Available) |- (Native);
 
 \draw let
-    \p1 = (Start),
-    \p2 = ($(Well.west)+(-1,0)$),
-    \p3 = (Q4),
-    \p4 = (Native),
+  \p1 = (Start),
+  \p2 = ($(Well.west)+(-1,0)$),
+  \p3 = (Q4),
+  \p4 = (Native),
 in
-    coordinate(C1) at (\x2,\y1)
-    coordinate(C2) at (\x2,\y2)
-    coordinate(C3) at (\x2,\y3)
-    coordinate(C4) at (\x2,\y4)
+  coordinate(C1) at (\x2,\y1)
+  coordinate(C2) at (\x2,\y2)
+  coordinate(C3) at (\x2,\y3)
+  coordinate(C4) at (\x2,\y4)
 ;
 
 \draw[bigArrow] (C1) -- node[onArrow, font=\bfseries] {Parse} ($(C2)+(0,0.25)$);

--- a/spec/tex/validity2.tex
+++ b/spec/tex/validity2.tex
@@ -39,14 +39,12 @@
   row sep=.5cm,
   column sep=.75cm,
 ] {
-  \node(Start) {
-    \begin{tikzpicture}[solid]
-    \draw (.5,0) arc (0:360:.5);
-    \foreach \angle in { 0, 45,..., 360 }{
-      \draw [rotate around={\angle:(0,0)}]
-        (.55,0) -- +(0,-.15) -- +(.3,0) -- +(0,.15) -- cycle;
-    };
-    \end{tikzpicture}
+
+  \node[circle, minimum size=1.75cm](Start) {};
+  \draw node[draw, circle, minimum size=1cm] at (Start) {};
+  \foreach \angle in { 45, 90,..., 360 }{
+    \draw [rotate around={\angle:(Start)}]
+      (.55,0) -- +(0,-.15) -- +(.3,0) -- +(0,.15) -- cycle;
   }; \\
 
   \node(Q1)[decision]; \\

--- a/spec/tex/validity2.tex
+++ b/spec/tex/validity2.tex
@@ -29,11 +29,6 @@
   goes/.style = {
     -{Latex[length=3mm]},
   },
-  bigArrow/.style = {
-    -{Latex[length=5mm]},
-    line width=1mm,
-    font=\bfseries,
-  },
 ]
 
 \matrix[

--- a/spec/tex/validity2.tex
+++ b/spec/tex/validity2.tex
@@ -32,6 +32,7 @@
   bigArrow/.style = {
     -{Latex[length=5mm]},
     line width=1mm,
+    font=\bfseries,
   },
 ]
 
@@ -103,9 +104,9 @@ in
   coordinate(C4) at (\x2,\y4)
 ;
 
-\draw[bigArrow] (C1) -- node[onArrow, font=\bfseries] {Parse} ($(C2)+(0,0.25)$);
-\draw[bigArrow] ($(C2)-(0,.25)$) -- node[onArrow, pos=.6, font=\bfseries] {Compose} ($(C3)+(0,0.25)$);
-\draw[bigArrow] ($(C3)-(0,.25)$) -- node[onArrow, pos=.6, font=\bfseries] {Construct} (C4);
+\draw[bigArrow] (C1) -- node[onArrow] {Parse} ($(C2)+(0,0.25)$);
+\draw[bigArrow] ($(C2)-(0,.25)$) -- node[onArrow, pos=.6] {Compose} ($(C3)+(0,0.25)$);
+\draw[bigArrow] ($(C3)-(0,.25)$) -- node[onArrow, pos=.6] {Construct} (C4);
 
 \draw ($(C2)-(.25,0)$) -- ($(C2)+(.25,0)$);
 \draw ($(C3)-(.25,0)$) -- ($(C3)+(.25,0)$);


### PR DESCRIPTION
- Use two-space tabs.
- Simplify drawing the sun symbol on the validity diagram.
- Generally clean up and simplify styling.