### PR TITLE
Mention duplicate mapping keys in loading failure points.

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1233,7 +1233,8 @@ The process of [loading] [native data structures] from a YAML [stream] has
 several potential _failure points_.
 The character [stream] may be [ill-formed], [aliases] may be [unidentified],
 [unspecified tags] may be [unresolvable], [tags] may be [unrecognized], the
-[content] may be [invalid] and a native type may be [unavailable].
+[content] may be [invalid], [mapping] [keys] may not be [unique] and a native
+type may be [unavailable].
 Each of these failures results with an incomplete loading.
 
 A _partial representation_ need not [resolve] the [tag] of each [node] and the


### PR DESCRIPTION
For #37.

This is a modest change, but I think it's valuable to mention duplicate mapping keys in the list of failure points, even if we don't add anything more.