### PR TITLE
Don't require authority in global tag prefix.

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -3251,7 +3251,7 @@ semantics to the same [local tag].
 ##### Global Tag Prefix
 
 > If the prefix begins with a character other than ["**`!`**"], it must be a
-valid URI prefix and should contain at least the scheme and the authority.
+valid URI prefix, and should contain at least the scheme.
 [Shorthands] using the associated [handle] are expanded to globally unique URI
 tags and their semantics is consistent across [applications].
 In particular, every [documents] in every [stream] must assign the same


### PR DESCRIPTION
For #38.

This cuts the gordian knot of figuring out whether a URL contains an authority component. It does not address the question of how errors should be handled, but I'm willing to bet that no implementation actually checks this or raises an error anyway. Arguably, we should at least weaken “it must to be a valid URI prefix” to “should”, but we can create another PR if we want.