### PR TITLE
Replace “Canonical Content” in diagrams with “Canonical Form”

### DIFF
--- a/spec/tex/model2.tex
+++ b/spec/tex/model2.tex
@@ -26,9 +26,9 @@
 \entity[below=of Node]{Scalar Node}{};
 \draw[inherits] (Scalar Node) -- (Node);
 
-\node[parallellogram, below=of Scalar Node](Canonical Content) {String};
-\draw[has] (Scalar Node) -- (Canonical Content)
-  node[onArrow, midway] {Canonical\\/ ++ Formatted\\Content};
+\node[parallellogram, below=of Scalar Node](Canonical Form) {String};
+\draw[has] (Scalar Node) -- (Canonical Form)
+  node[onArrow, midway] {Canonical Form/\\++ Formatted Content};
 
 \entity[left=of Scalar Node]{Sequence Node}{};
 \draw[inherits] (Sequence Node) -- ++(0,+10mm) -| (Node);
@@ -55,7 +55,7 @@
 \draw[has]
   (Mapping Node.east)
   -- ++(10mm, 0) node[near start, below] {*}
-  |- (Key/Value Pair) node[onArrow, pos=0.25] {Unordered\\/ + Ordered\\Content}
+  |- (Key/Value Pair) node[onArrow, pos=0.25] {Unordered/\\+ Ordered\\Content}
   node[at end, above right] {*};
 
 \draw[has] (Key/Value Pair.north)

--- a/spec/tex/present2.tex
+++ b/spec/tex/present2.tex
@@ -23,8 +23,8 @@
 \entity[below=of Node]{Scalar Node}{};
 \draw[inherits] (Scalar Node) -- (Node);
 
-\node[parallellogram, below=of Scalar Node](Canonical Content) {String};
-\draw[has] (Scalar Node) -- (Canonical Content)
+\node[parallellogram, below=of Scalar Node](Canonical Form) {String};
+\draw[has] (Scalar Node) -- (Canonical Form)
   node[onArrow, midway] {++ Formatted\\Content};
 
 \entity[left=of Scalar Node]{Sequence Node}{};

--- a/spec/tex/represent2.tex
+++ b/spec/tex/represent2.tex
@@ -19,9 +19,9 @@
 \entity[below=of Node]{Scalar Node}{};
 \draw[inherits] (Scalar Node) -- (Node);
 
-\node[parallellogram, below=of Scalar Node](Canonical Content) {String};
-\draw[has] (Scalar Node) -- (Canonical Content)
-  node[onArrow, midway] {Canonical\\Content};
+\node[parallellogram, below=of Scalar Node](Canonical Form) {String};
+\draw[has] (Scalar Node) -- (Canonical Form)
+  node[onArrow, midway] {Canonical\\Form};
 
 \entity[left=of Scalar Node]{Sequence Node}{};
 \draw[inherits] (Sequence Node) -- ++(0,+10mm) -| (Node);

--- a/spec/tex/serialize2.tex
+++ b/spec/tex/serialize2.tex
@@ -21,9 +21,9 @@
 \entity[below=of Node]{Scalar Node}{};
 \draw[inherits] (Scalar Node) -- (Node);
 
-\node[parallellogram, below=of Scalar Node](Canonical Content) {String};
-\draw[has] (Scalar Node) -- (Canonical Content)
-  node[onArrow, midway] {Canonical\\Content};
+\node[parallellogram, below=of Scalar Node](Canonical Form) {String};
+\draw[has] (Scalar Node) -- (Canonical Form)
+  node[onArrow, midway] {Canonical\\Form};
 
 \entity[left=of Scalar Node]{Sequence Node}{};
 \draw[inherits] (Sequence Node) -- ++(0,+10mm) -| (Node);


### PR DESCRIPTION
For #39.

Resolves the issue by always using the term “canonical form”, which is defined in the spec, instead of “canonical content”. (It was only ever used in the model diagrams.)

Minor layout tweak to the combined model diagram to make everything fit — the slashes are now at the ends of lines, not the beginning. This is probably better anyway.