### PR TITLE
Remove references to “event stream” in favor of “serialization tree”

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -883,15 +883,15 @@ following three stages:
 ##### Parsing the Presentation Stream
 
 > _Parsing_ is the inverse process of [presentation], it takes a [stream] of
-characters and produces a series of events.
+characters and produces a [serialization tree].
 Parsing discards all the [details] introduced in the [presentation] process,
-reporting only the [serialization] events.
+reporting only the [serialization tree].
 Parsing can fail due to [ill-formed] input.
 
 
 ##### Composing the Representation Graph
 
-> _Composing_ takes a series of [serialization] events and produces a
+> _Composing_ takes a [serialization tree] and produces a
 [representation graph].
 Composing discards all the [details] introduced in the [serialization] process,
 producing only the [representation graph].


### PR DESCRIPTION
For #42.

Use “serialization tree” consistently to refer to the product of parsing. Event streams were never defined in the spec, and the term “serialization tree” is defined and linkable and used in almost all places in the spec.

The spec still states:

> The result of this process, a YAML serialization tree, can then be traversed to produce a series of event calls for one-pass processing of YAML data.

We can add more wording along those lines if desired.