### PR TITLE
Add Valid Formatted Content for each scalar tag

### DIFF
--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -6417,13 +6417,14 @@ Also, a [mapping] entry with some [key] and a null [value] is valid and
 different from not having that [key] in the [mapping].
 
 
-? Canonical Form
-
-: **`null`**.
-
 ? Valid Formatted Content
 
 : Any of the strings `null`, `Null`, `NULL`, or `~`, or the empty string.
+
+
+? Canonical Form
+
+: **`null`**.
 
 
 **Example #. `!!null` Examples**

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -6421,7 +6421,6 @@ different from not having that [key] in the [mapping].
 
 : **`null`**.
 
-
 ? Valid Formatted Content
 
 : Any of the strings `null`, `Null`, `NULL`, or `~`, or the empty string.

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -6349,9 +6349,14 @@ This type is usually [bound] to the [native] language's string type or, for
 languages lacking one (such as C), to a character array.
 
 
+? Valid Formatted Content
+
+: Any string.
+
+
 ? Canonical Form:
 
-: The obvious.
+: The same as the formatted content.
 
 
 **Example #. `!!str` Examples**
@@ -6416,6 +6421,12 @@ different from not having that [key] in the [mapping].
 
 : **`null`**.
 
+
+? Valid Formatted Content
+
+: Any of the strings `null`, `Null`, `NULL`, or `~`, or the empty string.
+
+
 **Example #. `!!null` Examples**
 
 ```
@@ -6441,6 +6452,11 @@ key with null value: !!null null
 : [Represents] a true/false value.
 In languages without a [native] Boolean type (such as C), they are usually
 [bound] to a native integer type, using one for true and zero for false.
+
+
+? Valid Formatted Content:
+
+: Any of the strings `true`, `True`, `TRUE`, `false`, `False`, or `FALSE`.
 
 
 ? Canonical Form
@@ -6487,10 +6503,19 @@ In general, integers representable using 32 binary digits should safely
 round-trip through most systems.
 
 
+? Valid Formatted Content
+
+: A string matching any of the following regular expressions:
+
+  * **`[-+]? [0-9]+`**
+  * **`0o [0-7]+`**
+  * **`0x [0-9a-fA-F]+`**
+
+
 ? Canonical Form
 
 : Decimal integer notation, with a leading "**`-`**" character for negative
-values, matching the regular expression **`0 | -? [1-9] [0-9]*`**
+values, matching the regular expression **`0 | -? [1-9] [0-9]*`**.
 
 
 **Example #. `!!int` Examples**
@@ -6531,6 +6556,15 @@ The supported range and accuracy depends on the implementation, though 32 bit
 IEEE floats should be safe.
 Since YAML does not specify a particular accuracy, using floating-point
 [mapping keys] requires great care and is not recommended.
+
+
+? Valid Formatted Content
+
+: A string matching any of the following regular expressions:
+
+  * **`[-+]? ( \. [0-9]+ | [0-9]+ ( \. [0-9]* )? ) ( [eE] [-+]? [0-9]+ )?`**
+  * **`[-+]? ( \.inf | \.Inf | \.INF )`**
+  * **`\.nan | \.NaN | \.NAN`**
 
 
 ? Canonical Form

--- a/tool/bin/markydown-to-kramdown
+++ b/tool/bin/markydown-to-kramdown
@@ -178,7 +178,7 @@ sub parse_sections {
     s/\A(!\[.*\.svg\)\n)\s+//
       and push @s, {img => $1} and next;
 
-    s/\A(\* .*\n(?:  \S.*\n|\n(?=  \S))+)\n+//
+    s/\A( *\* .*\n(?:  \S.*\n|\n(?=  \S))+)\n+//
       and push @s, {ul => $1} and next;
 
     s/\A(\`\w.*\n)\n+//
@@ -400,7 +400,11 @@ sub fmt_img {}
 
 sub fmt_table {}
 
+
 sub fmt_footnote {}
+
+sub fmt_other {}
+
 
 #------------------------------------------------------------------------------
 sub read_files {

--- a/tool/bin/markydown-to-kramdown
+++ b/tool/bin/markydown-to-kramdown
@@ -400,11 +400,9 @@ sub fmt_img {}
 
 sub fmt_table {}
 
-
 sub fmt_footnote {}
 
 sub fmt_other {}
-
 
 #------------------------------------------------------------------------------
 sub read_files {
@@ -505,7 +503,9 @@ sub rule_link {
 
 sub format_links {
   s{
-    \[ (?!\^)
+    \[
+      (?!\^)
+      (?!eE\])
       (
         [^-0-9\`\]]
         [^\]]*?


### PR DESCRIPTION
For #53.

Add a “Valid formatted content” section for each scalar tag. Invalid content is already defined in 3.3.3, so this should suffice.

I had to modify the perl script so that it wouldn't try to turn `[eE]` into a link. The modification is a hack, but doing it properly (not looking for links in `<code>` tags) looks like it would be complicated.