### PR TITLE
Specify that implementations may recognize tags outside the schema.

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -5984,6 +5984,7 @@ next [document].
 
 A YAML _schema_ is a combination of a set of [tags] and a mechanism for
 [resolving] [non-specific tags].
+Implementations may [recognize] [tags] outside the specified schema.
 
 
 ## #. Failsafe Schema


### PR DESCRIPTION
It may also be useful to further specify that, e.g.:

> Implementations may recognize tags outside the specified schema provided that the implementation can produce the canonical form for each tag.