### PR TITLE
Replace spurious blockquotes with definition lists.

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -265,13 +265,13 @@ In particular, the following words are used to describe the actions of a YAML
 [processor]:
 
 
-May
+? May
 
 : The word _may_ or the adjective _optional_ mean that conforming YAML
 [processors] are permitted to, but _need not_ behave as described.
 
 
-Should
+? Should
 
 : The word _should_ or the adjective _recommended_ mean that there could be
 reasons for a YAML [processor] to deviate from the behavior described, but that
@@ -279,7 +279,7 @@ such deviation could hurt interoperability and should therefore be advertised
 with appropriate notice.
 
 
-Must
+? Must
 
 : The word _must_ or the term _required_ or _shall_ mean that the behavior
 described is an absolute requirement of the specification.
@@ -828,7 +828,7 @@ _Dumping_ native data structures to a character [stream] is done using the
 following three stages:
 
 
-Representing Native Data Structures
+? Representing Native Data Structures
 
 : YAML _represents_ any _native data structure_ using three [node kinds]:
 [sequence] - an ordered series of entries; [mapping] - an unordered association
@@ -853,7 +853,7 @@ This simple model can represent any data structure independent of programming
 language.
 
 
-Serializing the Representation Graph
+? Serializing the Representation Graph
 
 : For sequential access mediums, such as an event callback API, a YAML
 [representation] must be _serialized_ to an ordered tree.
@@ -869,7 +869,7 @@ The result of this process, a YAML [serialization tree], can then be traversed
 to produce a series of event calls for one-pass processing of YAML data.
 
 
-Presenting the Serialization Tree
+? Presenting the Serialization Tree
 
 : The final output process is _presenting_ the YAML [serializations] as a
 character [stream] in a human-friendly manner.
@@ -890,7 +890,7 @@ _Loading_ [native data structures] from a character [stream] is done using the
 following three stages:
 
 
-Parsing the Presentation Stream
+? Parsing the Presentation Stream
 
 : _Parsing_ is the inverse process of [presentation], it takes a [stream] of
 characters and produces a [serialization tree].
@@ -899,7 +899,7 @@ reporting only the [serialization tree].
 Parsing can fail due to [ill-formed] input.
 
 
-Composing the Representation Graph
+? Composing the Representation Graph
 
 : _Composing_ takes a [serialization tree] and produces a
 [representation graph].
@@ -908,7 +908,7 @@ producing only the [representation graph].
 Composing can fail due to any of several reasons, detailed [below].
 
 
-Constructing Native Data Structures
+? Constructing Native Data Structures
 
 : The final input process is _constructing_ [native data structures] from the
 YAML [representation].
@@ -1411,7 +1411,7 @@ These complications are of course the source of most of YAML's power to
 Productions use any of the following parameters:
 
 
-Indentation: `n` or `m`
+? Indentation: `n` or `m`
 
 : Many productions use an explicit [indentation] level parameter.
 This is less elegant than Python's "indent" and "undent" conceptual tokens.
@@ -1420,7 +1420,7 @@ However it is required to formally express YAML's indentation rules.
 : A value of `n/a` means "not applicable".
 
 
-Context: `c`
+? Context: `c`
 
 : This parameter allows productions to tweak their behavior according to their
 surrounding.
@@ -1444,7 +1444,7 @@ mapping] (_flow-key_); as values inside a [flow collection] (_flow-in_); or as
 values outside one (_flow-out_).
 
 
-(Block) Chomping: `t`
+? (Block) Chomping: `t`
 
 : Block scalars offer three possible mechanisms for [chomping] any trailing
 [line breaks]: [strip], [clip] and [keep].
@@ -1459,41 +1459,41 @@ Hungarian-style naming convention.
 Each production is given a prefix based on the type of characters it begins and
 ends with.
 
-**`e-`**
+? **`e-`**
 
 : A production matching no characters.
 
-**`c-`**
+? **`c-`**
 
 : A production starting and ending with a special character.
 
-**`b-`**
+? **`b-`**
 
 : A production matching a single [line break].
 
-**`nb-`**
+? **`nb-`**
 
 : A production starting and ending with a non-[break] character.
 
-**`s-`**
+? **`s-`**
 
 : A production starting and ending with a [white space] character.
 
-**`ns-`**
+? **`ns-`**
 
 : A production starting and ending with a non-[space] character.
 
-**`l-`**
+? **`l-`**
 
 : A production matching complete line(s).
 
-`X`**`-`**`Y`**`-`**
+? `X`**`-`**`Y`**`-`**
 
 : A production starting with an `X`**`-`** character and ending with a
 `Y`**`-`** character, where `X`**`-`** and `Y`**`-`** are any of the above
 prefixes.
 
-`X`**`+`**, `X`**`-`**`Y`**`+`**
+? `X`**`+`**, `X`**`-`**`Y`**`+`**
 
 : A production as above, with the additional property that the matched content
 [indentation] level is greater than the specified `n` parameter.
@@ -5949,7 +5949,7 @@ with the above **`l-yaml-stream`** production.
 Some common use case that can take advantage of the YAML stream structure are:
 
 
-Appending to Streams
+? Appending to Streams
 
 : Allowing multiple [documents] in a single stream makes YAML suitable for log
 files and similar [applications].
@@ -5957,7 +5957,7 @@ Note that each [document] is independent of the rest, allowing for
 heterogeneous log file entries.
 
 
-Concatenating Streams
+? Concatenating Streams
 
 : Concatenating two YAML streams requires both to use the same [character
 encoding].
@@ -5970,7 +5970,7 @@ In particular, either or both may be empty and the first stream may or may not
 already contain such a marker.
 
 
-Communication Streams
+? Communication Streams
 
 : The [document end marker] allows signaling the end of a [document] without
 closing the stream or starting the next [document].
@@ -5999,17 +5999,17 @@ option.
 
 #### #. Generic Mapping
 
-URI
+? URI
 
 : **`tag:yaml.org,2002:map`**
 
 
-Kind
+? Kind
 
 : [Mapping].
 
 
-Definition
+? Definition
 
 : [Represents] an associative container, where each [key] is unique in the
 association and mapped to exactly one [value].
@@ -6033,17 +6033,17 @@ Flow style: !!map { Clark: Evans, Ingy: döt Net, Oren: Ben-Kiki }
 
 #### #. Generic Sequence
 
-URI
+? URI
 
 : **`tag:yaml.org,2002:seq`**
 
 
-Kind
+? Kind
 
 : [Sequence].
 
 
-Definition
+? Definition
 
 : [Represents] a collection indexed by sequential integers starting with zero.
 Example [bindings] to [native] types include Perl's array, Python's list or
@@ -6063,24 +6063,24 @@ Flow style: !!seq [ Clark Evans, Ingy döt Net, Oren Ben-Kiki ]
 
 #### #. Generic String
 
-URI
+? URI
 
 : **`tag:yaml.org,2002:str`**
 
 
-Kind
+? Kind
 
 : [Scalar].
 
 
-Definition
+? Definition
 
 : [Represents] a Unicode string, a sequence of zero or more Unicode characters.
 This type is usually [bound] to the [native] language's string type or, for
 languages lacking one (such as C), to a character array.
 
 
-Canonical Form:
+? Canonical Form:
 
 : The obvious.
 
@@ -6123,17 +6123,17 @@ The JSON [schema] uses the following [tags] in addition to those defined by the
 
 #### #. Null
 
-URI
+? URI
 
 : **`tag:yaml.org,2002:null`**
 
 
-Kind
+? Kind
 
 : [Scalar].
 
 
-Definition
+? Definition
 
 : [Represents] the lack of a value.
 This is typically [bound] to a [native] null-like value (e.g., **`undef`** in
@@ -6143,7 +6143,7 @@ Also, a [mapping] entry with some [key] and a null [value] is valid and
 different from not having that [key] in the [mapping].
 
 
-Canonical Form
+? Canonical Form
 
 : **`null`**.
 
@@ -6157,24 +6157,24 @@ key with null value: !!null null
 
 #### #. Boolean
 
-URI
+? URI
 
 : **`tag:yaml.org,2002:bool`**
 
 
-Kind
+? Kind
 
 : [Scalar].
 
 
-Definition
+? Definition
 
 : [Represents] a true/false value.
 In languages without a [native] Boolean type (such as C), they are usually
 [bound] to a native integer type, using one for true and zero for false.
 
 
-Canonical Form
+? Canonical Form
 
 : Either **`true`** or **`false`**.
 
@@ -6189,17 +6189,17 @@ Pluto is a planet: !!bool false
 
 #### #. Integer
 
-URI
+? URI
 
 : **`tag:yaml.org,2002:int`**
 
 
-Kind
+? Kind
 
 : [Scalar].
 
 
-Definition
+? Definition
 
 : [Represents] arbitrary sized finite mathematical integers.
 Scalars of this type should be [bound] to a [native] integer data type, if
@@ -6218,7 +6218,7 @@ In general, integers representable using 32 binary digits should safely
 round-trip through most systems.
 
 
-Canonical Form
+? Canonical Form
 
 : Decimal integer notation, with a leading "**`-`**" character for negative
 values, matching the regular expression **`0 | -? [1-9] [0-9]*`**
@@ -6235,17 +6235,17 @@ positive: !!int 34
 
 #### #. Floating Point
 
-URI
+? URI
 
 : **`tag:yaml.org,2002:float`**
 
 
-Kind
+? Kind
 
 : [Scalar].
 
 
-Definition
+? Definition
 
 : [Represents] an approximation to real numbers, including three special values
 (positive and negative infinity and "not a number").
@@ -6264,7 +6264,7 @@ Since YAML does not specify a particular accuracy, using floating-point
 [mapping keys] requires great care and is not recommended.
 
 
-Canonical Form
+? Canonical Form
 
 : Either **`0`**, **`.inf`**, **`-.inf`**, **`.nan`** or scientific notation
 matching the regular expression  

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -265,23 +265,23 @@ In particular, the following words are used to describe the actions of a YAML
 [processor]:
 
 
-##### May
+May
 
-> The word _may_ or the adjective _optional_ mean that conforming YAML
+: The word _may_ or the adjective _optional_ mean that conforming YAML
 [processors] are permitted to, but _need not_ behave as described.
 
 
-##### Should
+Should
 
-> The word _should_ or the adjective _recommended_ mean that there could be
+: The word _should_ or the adjective _recommended_ mean that there could be
 reasons for a YAML [processor] to deviate from the behavior described, but that
 such deviation could hurt interoperability and should therefore be advertised
 with appropriate notice.
 
 
-##### Must
+Must
 
-> The word _must_ or the term _required_ or _shall_ mean that the behavior
+: The word _must_ or the term _required_ or _shall_ mean that the behavior
 described is an absolute requirement of the specification.
 
 The rest of this document is arranged as follows.
@@ -828,19 +828,20 @@ _Dumping_ native data structures to a character [stream] is done using the
 following three stages:
 
 
-##### Representing Native Data Structures
+Representing Native Data Structures
 
-> YAML _represents_ any _native data structure_ using three [node kinds]:
+: YAML _represents_ any _native data structure_ using three [node kinds]:
 [sequence] - an ordered series of entries; [mapping] - an unordered association
 of [unique] [keys] to [values]; and [scalar] - any datum with opaque structure
 presentable as a series of Unicode characters.
-Combined, these primitives generate directed graph structures.
+
+: Combined, these primitives generate directed graph structures.
 These primitives were chosen because they are both powerful and familiar: the
 [sequence] corresponds to a Perl array and a Python list, the [mapping]
 corresponds to a Perl hash table and a Python dictionary.
 The [scalar] represents strings, integers, dates and other atomic data types.
 
-> Each YAML [node] requires, in addition to its [kind] and [content], a [tag]
+: Each YAML [node] requires, in addition to its [kind] and [content], a [tag]
 specifying its data type.
 Type specifiers are either [global] URIs or are [local] in scope to a single
 [application].
@@ -852,9 +853,9 @@ This simple model can represent any data structure independent of programming
 language.
 
 
-##### Serializing the Representation Graph
+Serializing the Representation Graph
 
-> For sequential access mediums, such as an event callback API, a YAML
+: For sequential access mediums, such as an event callback API, a YAML
 [representation] must be _serialized_ to an ordered tree.
 Since in a YAML [representation], [mapping keys] are unordered and [nodes] may
 be referenced more than once (have more than one incoming "arrow"), the
@@ -868,9 +869,9 @@ The result of this process, a YAML [serialization tree], can then be traversed
 to produce a series of event calls for one-pass processing of YAML data.
 
 
-##### Presenting the Serialization Tree
+Presenting the Serialization Tree
 
-> The final output process is _presenting_ the YAML [serializations] as a
+: The final output process is _presenting_ the YAML [serializations] as a
 character [stream] in a human-friendly manner.
 To maximize human readability, YAML offers a rich set of stylistic options
 which go far beyond the minimal functional needs of simple data storage.
@@ -889,27 +890,27 @@ _Loading_ [native data structures] from a character [stream] is done using the
 following three stages:
 
 
-##### Parsing the Presentation Stream
+Parsing the Presentation Stream
 
-> _Parsing_ is the inverse process of [presentation], it takes a [stream] of
+: _Parsing_ is the inverse process of [presentation], it takes a [stream] of
 characters and produces a [serialization tree].
 Parsing discards all the [details] introduced in the [presentation] process,
 reporting only the [serialization tree].
 Parsing can fail due to [ill-formed] input.
 
 
-##### Composing the Representation Graph
+Composing the Representation Graph
 
-> _Composing_ takes a [serialization tree] and produces a
+: _Composing_ takes a [serialization tree] and produces a
 [representation graph].
 Composing discards all the [details] introduced in the [serialization] process,
 producing only the [representation graph].
 Composing can fail due to any of several reasons, detailed [below].
 
 
-##### Constructing Native Data Structures
+Constructing Native Data Structures
 
-> The final input process is _constructing_ [native data structures] from the
+: The final input process is _constructing_ [native data structures] from the
 YAML [representation].
 Construction must be based only on the information available in the
 [representation] and not on additional [serialization] or [presentation
@@ -980,22 +981,22 @@ In addition, each node has a [tag] which serves to restrict the set of possible
 values the content can have.
 
 
-##### Scalar
+? Scalar
 
-> The content of a _scalar_ node is an opaque datum that can be [presented] as
+: The content of a _scalar_ node is an opaque datum that can be [presented] as
 a series of zero or more Unicode characters.
 
 
-##### Sequence
+? Sequence
 
-> The content of a _sequence_ node is an ordered series of zero or more nodes.
+: The content of a _sequence_ node is an ordered series of zero or more nodes.
 In particular, a sequence may contain the same node more than once.
 It could even contain itself (directly or indirectly).
 
 
-##### Mapping
+? Mapping
 
-> The content of a _mapping_ node is an unordered set of _key:_ _value_ node
+: The content of a _mapping_ node is an unordered set of _key:_ _value_ node
 _pairs_, with the restriction that each of the keys is [unique].
 YAML places no further restrictions on the nodes.
 In particular, keys may be arbitrary nodes, the same node may be used as the
@@ -1058,9 +1059,9 @@ If both notations are used as [keys] in the same [mapping], only a YAML
 duplicate [key] as an error.
 
 
-##### Canonical Form
+? Canonical Form
 
-> YAML supports the need for [scalar] equality by requiring that every
+: YAML supports the need for [scalar] equality by requiring that every
 [scalar] [tag] must specify a mechanism for producing the _canonical form_ of
 any [formatted content].
 This form is a Unicode character string which also [presents] the same
@@ -1069,9 +1070,9 @@ While this requirement is stronger than a well defined equality operator, it
 has other uses, such as the production of digital signatures.
 
 
-##### Equality
+? Equality
 
-> Two [nodes] must have the same [tag] and [content] to be _equal_.
+: Two [nodes] must have the same [tag] and [content] to be _equal_.
 Since each [tag] applies to exactly one [kind], this implies that the two
 [nodes] must have the same [kind] to be equal.
 Two [scalars] are equal only when their [tags] and canonical forms are equal
@@ -1084,7 +1085,7 @@ Two [mappings] are equal only when they have the same [tag] and an equal set of
 [keys] and each [key] in this set is associated with equal [values] in both
 [mappings].
 
-> Different URI schemes may define different rules for testing the equality of
+: Different URI schemes may define different rules for testing the equality of
 URIs.
 Since a YAML [processor] cannot be reasonably expected to be aware of them all,
 it must resort to a simple character-by-character comparison of [tags] to
@@ -1095,14 +1096,14 @@ scheme.
 that such comparison would yield the correct results.
 
 
-##### Uniqueness
+? Uniqueness
 
-> A [mapping's] [keys] are _unique_ if no two keys are equal to each other.
+: A [mapping's] [keys] are _unique_ if no two keys are equal to each other.
 
 
-##### Identity
+? Identity
 
-> Two [nodes] are _identical_ only when they [represent] the same [native data
+: Two [nodes] are _identical_ only when they [represent] the same [native data
 structure].
 Typically, this corresponds to a single memory address.
 Identity should not be confused with equality; two equal [nodes] need not have
@@ -1410,29 +1411,29 @@ These complications are of course the source of most of YAML's power to
 Productions use any of the following parameters:
 
 
-##### Indentation: `n` or `m`
+Indentation: `n` or `m`
 
-> Many productions use an explicit [indentation] level parameter.
+: Many productions use an explicit [indentation] level parameter.
 This is less elegant than Python's "indent" and "undent" conceptual tokens.
 However it is required to formally express YAML's indentation rules.
 
-> A value of `n/a` means "not applicable".
+: A value of `n/a` means "not applicable".
 
 
-##### Context: `c`
+Context: `c`
 
-> This parameter allows productions to tweak their behavior according to their
+: This parameter allows productions to tweak their behavior according to their
 surrounding.
 YAML supports two groups of _contexts_, distinguishing between [block styles]
 and [flow styles].
 
-> In [block styles], [indentation] is used to delineate structure.
+: In [block styles], [indentation] is used to delineate structure.
 To capture human perception of [indentation] the rules require special
 treatment of the ["**`-`**"] character, used in [block sequences].
 Hence in some cases productions need to behave differently inside [block
 sequences] (_block-in context_) and outside them (_block-out context_).
 
-> In [flow styles], explicit [indicators] are used to delineate structure.
+: In [flow styles], explicit [indicators] are used to delineate structure.
 These styles can be viewed as the natural extension of JSON to cover [tagged],
 [single-quoted] and [plain scalars].
 Since the latter have no delineating [indicators], they are subject to some
@@ -1443,9 +1444,9 @@ mapping] (_flow-key_); as values inside a [flow collection] (_flow-in_); or as
 values outside one (_flow-out_).
 
 
-##### (Block) Chomping: `t`
+(Block) Chomping: `t`
 
-> Block scalars offer three possible mechanisms for [chomping] any trailing
+: Block scalars offer three possible mechanisms for [chomping] any trailing
 [line breaks]: [strip], [clip] and [keep].
 Unlike the previous parameters, this only controls interpretation; the [line
 breaks] are valid in all cases.
@@ -1460,41 +1461,41 @@ ends with.
 
 **`e-`**
 
-> A production matching no characters.
+: A production matching no characters.
 
 **`c-`**
 
-> A production starting and ending with a special character.
+: A production starting and ending with a special character.
 
 **`b-`**
 
-> A production matching a single [line break].
+: A production matching a single [line break].
 
 **`nb-`**
 
-> A production starting and ending with a non-[break] character.
+: A production starting and ending with a non-[break] character.
 
 **`s-`**
 
-> A production starting and ending with a [white space] character.
+: A production starting and ending with a [white space] character.
 
 **`ns-`**
 
-> A production starting and ending with a non-[space] character.
+: A production starting and ending with a non-[space] character.
 
 **`l-`**
 
-> A production matching complete line(s).
+: A production matching complete line(s).
 
 `X`**`-`**`Y`**`-`**
 
-> A production starting with an `X`**`-`** character and ending with a
+: A production starting with an `X`**`-`** character and ending with a
 `Y`**`-`** character, where `X`**`-`** and `Y`**`-`** are any of the above
 prefixes.
 
 `X`**`+`**, `X`**`-`**`Y`**`+`**
 
-> A production as above, with the additional property that the matched content
+: A production as above, with the additional property that the matched content
 [indentation] level is greater than the specified `n` parameter.
 
 
@@ -2674,16 +2675,16 @@ flow styles].
 Folding does distinguish between these cases in the following way:
 
 
-##### Block Folding
+? Block Folding
 
-> In the [folded block style], the final [line break] and trailing [empty
+: In the [folded block style], the final [line break] and trailing [empty
 lines] are subject to [chomping] and are never folded.
 In addition, folding does not apply to [line breaks] surrounding text lines
 that contain leading [white space].
 Note that such a [more-indented] line may consist only of such leading [white
 space].
 
-> The combined effect of the _block line folding_ rules is that each
+: The combined effect of the _block line folding_ rules is that each
 "paragraph" is interpreted as a line, [empty lines] are interpreted as a line
 feed and the formatting of [more-indented] lines is preserved.
 
@@ -2709,9 +2710,9 @@ feed and the formatting of [more-indented] lines is preserved.
 * Content spaces <!-- 2:6 4:3,2 -->
 
 
-##### Flow Folding
+? Flow Folding
 
-> Folding in [flow styles] provides more relaxed semantics.
+: Folding in [flow styles] provides more relaxed semantics.
 [Flow styles] typically depend on explicit [indicators] rather than
 [indentation] to convey structure.
 Hence spaces preceding or following the text in a line are a [presentation
@@ -2719,7 +2720,7 @@ detail] and must not be used to convey [content] information.
 Once all such spaces have been discarded, all [line breaks] are folded without
 exception.
 
-> The combined effect of the _flow line folding_ rules is that each "paragraph"
+: The combined effect of the _flow line folding_ rules is that each "paragraph"
 is interpreted as a line, [empty lines] are interpreted as line feeds and text
 can be freely [more-indented] without affecting the [content] information.
 
@@ -3109,16 +3110,16 @@ There are three tag handle variants:
 ```
 
 
-##### Primary Handle
+? Primary Handle
 
-> The _primary tag handle_ is a single _"**`!`**"_ character.
+: The _primary tag handle_ is a single _"**`!`**"_ character.
 This allows using the most compact possible notation for a single "primary"
 name space.
 By default, the prefix associated with this handle is ["**`!`**"].
 Thus, by default, [shorthands] using this handle are interpreted as [local
 tags].
 
-> It is possible to override the default behavior by providing an explicit
+: It is possible to override the default behavior by providing an explicit
 "**`TAG`**" directive, associating a different prefix for this handle.
 This provides smooth migration from using [local tags] to using [global tags]
 by the simple addition of a single "**`TAG`**" directive.
@@ -3150,15 +3151,15 @@ by the simple addition of a single "**`TAG`**" directive.
 * [c-primary-tag-handle] <!-- ! -->
 
 
-##### Secondary Handle
+? Secondary Handle
 
-> The _secondary tag handle_ is written as _"**`!!`**"_.
+: The _secondary tag handle_ is written as _"**`!!`**"_.
 This allows using a compact notation for a single "secondary" name space.
 By default, the prefix associated with this handle is
 "**`tag:yaml.org,2002:`**".
 This prefix is used by the [YAML tag repository].
 
-> It is possible to override this default behavior by providing an explicit
+: It is possible to override this default behavior by providing an explicit
 "**`TAG`**" directive associating a different prefix for this handle.
 
 ```
@@ -3183,13 +3184,13 @@ This prefix is used by the [YAML tag repository].
 * [c-secondary-tag-handle] <!-- !! -->
 
 
-##### Named Handles
+? Named Handles
 
-> A _named tag handle_ surrounds a non-empty name with _"**`!`**"_ characters.
+: A _named tag handle_ surrounds a non-empty name with _"**`!`**"_ characters.
 A handle name must not be used in a [tag shorthand] unless an explicit
 "**`TAG`**" directive has associated some prefix with it.
 
-> The name of the handle is a [presentation detail] and must not be used to
+: The name of the handle is a [presentation detail] and must not be used to
 convey [content] information.
 In particular, the YAML [processor] need not preserve the handle name once
 [parsing] is completed.
@@ -3226,9 +3227,9 @@ There are two _tag prefix_ variants:
 ```
 
 
-##### Local Tag Prefix
+? Local Tag Prefix
 
-> If the prefix begins with a ["**`!`**"] character, [shorthands] using the
+: If the prefix begins with a ["**`!`**"] character, [shorthands] using the
 [handle] are expanded to a [local tag].
 Note that such a [tag] is intentionally not a valid URI and its semantics are
 specific to the [application].
@@ -3263,9 +3264,9 @@ semantics to the same [local tag].
 * [c-ns-local-tag-prefix] <!-- !my- -->
 
 
-##### Global Tag Prefix
+? Global Tag Prefix
 
-> If the prefix begins with a character other than ["**`!`**"], it must be a
+: If the prefix begins with a character other than ["**`!`**"], it must be a
 valid URI prefix, and should contain at least the scheme.
 [Shorthands] using the associated [handle] are expanded to globally unique URI
 tags and their semantics is consistent across [applications].
@@ -3343,9 +3344,9 @@ A tag is denoted by the _"**`!`**" indicator_.
 ```
 
 
-##### Verbatim Tags
+? Verbatim Tags
 
-> A tag may be written _verbatim_ by surrounding it with the _"**`<`**" and
+: A tag may be written _verbatim_ by surrounding it with the _"**`<`**" and
 "**`>`**"_ characters.
 In this case, the YAML [processor] must deliver the verbatim tag as-is to the
 [application].
@@ -3394,9 +3395,9 @@ ERROR:
 <!-- 4:7,3 -->
 
 
-##### Tag Shorthands
+? Tag Shorthands
 
-> A _tag shorthand_ consists of a valid [tag handle] followed by a non-empty
+: A _tag shorthand_ consists of a valid [tag handle] followed by a non-empty
 suffix.
 The [tag handle] must be associated with a [prefix], either by default or by
 using a ["**`TAG`**" directive].
@@ -3404,11 +3405,11 @@ The resulting [parsed] [tag] is the concatenation of the [prefix] and the
 suffix and must either begin with ["**`!`**"] (a [local tag]) or be a valid URI
 (a [global tag]).
 
-> The choice of [tag handle] is a [presentation detail] and must not be used to
+: The choice of [tag handle] is a [presentation detail] and must not be used to
 convey [content] information.
 In particular, the [tag handle] may be discarded once [parsing] is completed.
 
-> The suffix must not contain any ["**`!`**"] character.
+: The suffix must not contain any ["**`!`**"] character.
 This would cause the tag shorthand to be interpreted as having a [named tag
 handle].
 In addition, the suffix must not contain the ["**`[`**"], ["**`]`**"],
@@ -3465,22 +3466,22 @@ ERROR:
 <!-- 3:7,3 -->
 
 
-##### Non-Specific Tags
+? Non-Specific Tags
 
-> If a [node] has no tag property, it is assigned a [non-specific tag] that
+: If a [node] has no tag property, it is assigned a [non-specific tag] that
 needs to be [resolved] to a [specific] one.
 This [non-specific tag] is ["**`!`**"] for non-[plain scalars] and ["**`?`**"]
 for all other [nodes].
 This is the only case where the [node style] has any effect on the [content]
 information.
 
-> It is possible for the tag property to be explicitly set to the ["**`!`**"
+: It is possible for the tag property to be explicitly set to the ["**`!`**"
 non-specific tag].
 By [convention], this "disables" [tag resolution], forcing the [node] to be
 interpreted as "**`tag:yaml.org,2002:seq`**", "**`tag:yaml.org,2002:map`**" or
 "**`tag:yaml.org,2002:str`**", according to its [kind].
 
-> There is no way to explicitly specify the ["**`?`**" non-specific] tag.
+: There is no way to explicitly specify the ["**`?`**" non-specific] tag.
 This is intentional.
 
 ```
@@ -4795,25 +4796,25 @@ interpreted.
 YAML provides three chomping methods:
 
 
-##### Strip
+? Strip
 
-> _Stripping_ is specified by the _"**`-`**" chomping indicator_.
+: _Stripping_ is specified by the _"**`-`**" chomping indicator_.
 In this case, the final [line break] and any trailing [empty lines] are
 excluded from the [scalar's content].
 
 
-##### Clip
+? Clip
 
-> _Clipping_ is the default behavior used if no explicit chomping indicator is
+: _Clipping_ is the default behavior used if no explicit chomping indicator is
 specified.
 In this case, the final [line break] character is preserved in the [scalar's
 content].
 However, any trailing [empty lines] are excluded from the [scalar's content].
 
 
-##### Keep
+? Keep
 
-> _Keeping_ is specified by the _"**`+`**" chomping indicator_.
+: _Keeping_ is specified by the _"**`+`**" chomping indicator_.
 In this case, the final [line break] and any trailing [empty lines] are
 considered to be part of the [scalar's content].
 These additional lines are not subject to [folding].
@@ -5948,17 +5949,17 @@ with the above **`l-yaml-stream`** production.
 Some common use case that can take advantage of the YAML stream structure are:
 
 
-##### Appending to Streams
+Appending to Streams
 
-> Allowing multiple [documents] in a single stream makes YAML suitable for log
+: Allowing multiple [documents] in a single stream makes YAML suitable for log
 files and similar [applications].
 Note that each [document] is independent of the rest, allowing for
 heterogeneous log file entries.
 
 
-##### Concatenating Streams
+Concatenating Streams
 
-> Concatenating two YAML streams requires both to use the same [character
+: Concatenating two YAML streams requires both to use the same [character
 encoding].
 In addition, it is necessary to separate the last [document] of the first
 stream and the first [document] of the second stream.
@@ -5969,9 +5970,9 @@ In particular, either or both may be empty and the first stream may or may not
 already contain such a marker.
 
 
-##### Communication Streams
+Communication Streams
 
-> The [document end marker] allows signaling the end of a [document] without
+: The [document end marker] allows signaling the end of a [document] without
 closing the stream or starting the next [document].
 This allows the receiver to complete processing a [document] without having to
 wait for the next one to arrive.
@@ -5998,19 +5999,19 @@ option.
 
 #### #. Generic Mapping
 
-##### URI:
+URI
 
-> **`tag:yaml.org,2002:map`**
-
-
-##### Kind:
-
-> [Mapping].
+: **`tag:yaml.org,2002:map`**
 
 
-##### Definition:
+Kind
 
-> [Represents] an associative container, where each [key] is unique in the
+: [Mapping].
+
+
+Definition
+
+: [Represents] an associative container, where each [key] is unique in the
 association and mapped to exactly one [value].
 YAML places no restrictions on the type of [keys]; in particular, they are not
 restricted to being [scalars].
@@ -6032,19 +6033,19 @@ Flow style: !!map { Clark: Evans, Ingy: döt Net, Oren: Ben-Kiki }
 
 #### #. Generic Sequence
 
-##### URI:
+URI
 
-> **`tag:yaml.org,2002:seq`**
-
-
-##### Kind:
-
-> [Sequence].
+: **`tag:yaml.org,2002:seq`**
 
 
-##### Definition:
+Kind
 
-> [Represents] a collection indexed by sequential integers starting with zero.
+: [Sequence].
+
+
+Definition
+
+: [Represents] a collection indexed by sequential integers starting with zero.
 Example [bindings] to [native] types include Perl's array, Python's list or
 tuple and Java's array or Vector.
 
@@ -6062,26 +6063,26 @@ Flow style: !!seq [ Clark Evans, Ingy döt Net, Oren Ben-Kiki ]
 
 #### #. Generic String
 
-##### URI:
+URI
 
-> **`tag:yaml.org,2002:str`**
-
-
-##### Kind:
-
-> [Scalar].
+: **`tag:yaml.org,2002:str`**
 
 
-##### Definition:
+Kind
 
-> [Represents] a Unicode string, a sequence of zero or more Unicode characters.
+: [Scalar].
+
+
+Definition
+
+: [Represents] a Unicode string, a sequence of zero or more Unicode characters.
 This type is usually [bound] to the [native] language's string type or, for
 languages lacking one (such as C), to a character array.
 
 
-##### Canonical Form:
+Canonical Form:
 
-> The obvious.
+: The obvious.
 
 
 **Example #. `!!str` Examples**
@@ -6122,19 +6123,19 @@ The JSON [schema] uses the following [tags] in addition to those defined by the
 
 #### #. Null
 
-##### URI:
+URI
 
-> **`tag:yaml.org,2002:null`**
-
-
-##### Kind:
-
-> [Scalar].
+: **`tag:yaml.org,2002:null`**
 
 
-##### Definition:
+Kind
 
-> [Represents] the lack of a value.
+: [Scalar].
+
+
+Definition
+
+: [Represents] the lack of a value.
 This is typically [bound] to a [native] null-like value (e.g., **`undef`** in
 Perl, **`None`** in Python).
 Note that a null is different from an empty string.
@@ -6142,9 +6143,9 @@ Also, a [mapping] entry with some [key] and a null [value] is valid and
 different from not having that [key] in the [mapping].
 
 
-##### Canonical Form:
+Canonical Form
 
-> **`null`**.
+: **`null`**.
 
 **Example #. `!!null` Examples**
 
@@ -6156,26 +6157,26 @@ key with null value: !!null null
 
 #### #. Boolean
 
-##### URI:
+URI
 
-> **`tag:yaml.org,2002:bool`**
-
-
-##### Kind:
-
-> [Scalar].
+: **`tag:yaml.org,2002:bool`**
 
 
-##### Definition:
+Kind
 
-> [Represents] a true/false value.
+: [Scalar].
+
+
+Definition
+
+: [Represents] a true/false value.
 In languages without a [native] Boolean type (such as C), they are usually
 [bound] to a native integer type, using one for true and zero for false.
 
 
-##### Canonical Form:
+Canonical Form
 
-> Either **`true`** or **`false`**.
+: Either **`true`** or **`false`**.
 
 
 **Example #. `!!bool` Examples**
@@ -6188,28 +6189,28 @@ Pluto is a planet: !!bool false
 
 #### #. Integer
 
-##### URI:
+URI
 
-> **`tag:yaml.org,2002:int`**
-
-
-##### Kind:
-
-> [Scalar].
+: **`tag:yaml.org,2002:int`**
 
 
-##### Definition:
+Kind
 
-> [Represents] arbitrary sized finite mathematical integers.
+: [Scalar].
+
+
+Definition
+
+: [Represents] arbitrary sized finite mathematical integers.
 Scalars of this type should be [bound] to a [native] integer data type, if
 possible.
 
-> Some languages (such as Perl) provide only a "number" type that allows for
+: Some languages (such as Perl) provide only a "number" type that allows for
 both integer and floating-point values.
 A YAML [processor] may use such a type for integers as long as they round-trip
 properly.
 
-> In some languages (such as C), an integer may overflow the [native] type's
+: In some languages (such as C), an integer may overflow the [native] type's
 storage capability.
 A YAML [processor] may reject such a value as an error, truncate it with a
 warning or find some other manner to round-trip it.
@@ -6217,9 +6218,9 @@ In general, integers representable using 32 binary digits should safely
 round-trip through most systems.
 
 
-##### Canonical Form:
+Canonical Form
 
-> Decimal integer notation, with a leading "**`-`**" character for negative
+: Decimal integer notation, with a leading "**`-`**" character for negative
 values, matching the regular expression **`0 | -? [1-9] [0-9]*`**
 
 
@@ -6234,27 +6235,27 @@ positive: !!int 34
 
 #### #. Floating Point
 
-##### URI:
+URI
 
-> **`tag:yaml.org,2002:float`**
-
-
-##### Kind:
-
-> [Scalar].
+: **`tag:yaml.org,2002:float`**
 
 
-##### Definition:
+Kind
 
-> [Represents] an approximation to real numbers, including three special values
+: [Scalar].
+
+
+Definition
+
+: [Represents] an approximation to real numbers, including three special values
 (positive and negative infinity and "not a number").
 
-> Some languages (such as Perl) provide only a "number" type that allows for
+: Some languages (such as Perl) provide only a "number" type that allows for
 both integer and floating-point values.
 A YAML [processor] may use such a type for floating-point numbers, as long as
 they round-trip properly.
 
-> Not all floating-point values can be stored exactly in any given [native]
+: Not all floating-point values can be stored exactly in any given [native]
 type.
 Hence a float value may change by "a small amount" when round-tripped.
 The supported range and accuracy depends on the implementation, though 32 bit
@@ -6263,9 +6264,9 @@ Since YAML does not specify a particular accuracy, using floating-point
 [mapping keys] requires great care and is not recommended.
 
 
-##### Canonical Form:
+Canonical Form
 
-> Either **`0`**, **`.inf`**, **`-.inf`**, **`.nan`** or scientific notation
+: Either **`0`**, **`.inf`**, **`-.inf`**, **`.nan`** or scientific notation
 matching the regular expression  
 **`-? [1-9] ( \. [0-9]* [1-9] )? ( e [-+] [1-9] [0-9]* )?`**.
 

--- a/tool/bin/markydown-to-kramdown
+++ b/tool/bin/markydown-to-kramdown
@@ -97,6 +97,10 @@ sub parse_sections {
     s/\A(#{1,5} .*\n)\n+//
       and push @s, {heading => $1} and next;
 
+    # Definition term:
+    s/\A\? (.*)\n+//
+      and push @s, {dt => $1} and next;
+
     # Unordered list:
     s/\A
       (
@@ -146,6 +150,17 @@ sub parse_sections {
       )
       \n+
     }{}x and push @s, {indent => $1} and next;
+
+    # Definition definition:
+    s{\A
+      (
+        : $s+ $line
+        (?:
+          \S $line
+        )*
+      )
+      \n+
+    }{}x and push @s, {dd => $1} and next;
 
     s/\A(----\n)\n+//
       and push @s, {hr => $1} and next;
@@ -236,6 +251,15 @@ sub fmt_heading {
   $_ = qq{<div id="$slug" />\n$text\n};
 }
 
+sub fmt_dt {
+  set_dates();
+
+  my $text = $_;
+  my $slug = slugify($text);
+
+  $_ = qq{<div id="$slug" />\n\n$text\n};
+}
+
 sub fmt_example {
   my ($title, $yaml1, $yaml2, $legend) = @$_;
 
@@ -324,6 +348,10 @@ sub fmt_p {
     $figure++;
     s/^\*\*Figure #\./**Figure $chapter.$figure./;
   }
+}
+
+sub fmt_dd {
+  format_links();
 }
 
 sub fmt_hr {}

--- a/www/src/spec.scss
+++ b/www/src/spec.scss
@@ -153,3 +153,9 @@ span.footnote-link {
     background-color: inherit;
   }
 }
+
+dt {
+  // font-weight: inherit;
+  font-weight: normal !important;
+  color: #159957;
+}


### PR DESCRIPTION
Currently, the spec uses a combination of level-5 headings and blockquotes to emulate a definition list-like layout. But Kramdown supports actual definition lists, so this is unnecessary. Where we can use the proper semantic markup, we should do so.

As a bonus, the headings I replaced were exactly the ones that we didn't want in the table of contents, so that's fixed too.

This PR makes two changes to the perl script. The first is simply to pass through definitions without incident. The second introduces a new syntax for adding anchors. Some of the headings that are now definition terms were used as link targets, so we have to make sure that the definition terms have the same anchors. Kramdown has built-in syntax for this, but the perl script didn't like it, so here I'm using question marks. The following example:

```
? Scalar
```

…will be expanded to:

```
<div id="scalar"/>

Scalar
```