### PR TITLE
Incorporate RFC 2119 by reference.

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -259,30 +259,10 @@ For more information on using both XML and YAML, please visit
 
 ## #. Terminology
 
-This specification uses key words based on the [RFC format^] to indicate
-requirement level.
-In particular, the following words are used to describe the actions of a YAML
-[processor]:
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119^].
 
-
-? May
-
-: The word _may_ or the adjective _optional_ mean that conforming YAML
-[processors] are permitted to, but _need not_ behave as described.
-
-
-? Should
-
-: The word _should_ or the adjective _recommended_ mean that there could be
-reasons for a YAML [processor] to deviate from the behavior described, but that
-such deviation could hurt interoperability and should therefore be advertised
-with appropriate notice.
-
-
-? Must
-
-: The word _must_ or the term _required_ or _shall_ mean that the behavior
-described is an absolute requirement of the specification.
 
 The rest of this document is arranged as follows.
 Chapter [2] provides a short preview of the main YAML features.
@@ -6494,9 +6474,9 @@ well as raising any questions regarding this draft.
 * Python
   * [The Python Programming Language](
     https://www.python.org/)
-* RFC format
-  * [Request for Comments Summary](
-    https://tools.ietf.org/html/rfc2199)
+* RFC 2119
+  * [RFC 2119: Key words for use in RFCs to Indicate Requirement Levels](
+    https://tools.ietf.org/html/rfc2119)
 * Ruby
   * [Ruby Programming Language](
     https://www.ruby-lang.org/)

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -6475,7 +6475,7 @@ well as raising any questions regarding this draft.
   * [The Python Programming Language](
     https://www.python.org/)
 * RFC 2119
-  * [RFC 2119: Key words for use in RFCs to Indicate Requirement Levels](
+  * [Key words for use in RFCs to Indicate Requirement Levels](
     https://tools.ietf.org/html/rfc2119)
 * Ruby
   * [Ruby Programming Language](

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -261,7 +261,7 @@ For more information on using both XML and YAML, please visit
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in [RFC 2119^].
+interpreted as described in RFC 2119[^RFC-2119].
 
 The rest of this document is arranged as follows.
 Chapter [2] provides a short preview of the main YAML features.
@@ -6441,7 +6441,7 @@ well as raising any questions regarding this draft.
 [^SAX]: [Wikipedia - Simple API for XML](https://en.wikipedia.org/wiki/Simple_API_for_XML)
 [^SOAP]: [SOAP](https://en.wikipedia.org/wiki/SOAP)
 [^JSON]: [The JSON data interchange syntax](https://www.ecma-international.org/publications-and-standards/standards/ecma-404/)
-[^RFC-2119]: [Request for Comments Summary](https://tools.ietf.org/html/rfc2119)
+[^RFC-2119]: [Key words for use in RFCs to Indicate Requirement Levels](https://tools.ietf.org/html/rfc2119)
 [^digraph]: [directed graph](https://xlinux.nist.gov/dads/HTML/directedGraph.html)
 [^tag-uri]: [The 'tag' URI Scheme](https://datatracker.ietf.org/doc/html/rfc4151)
 [^yaml-ref]: [YamlReference: YAML reference implementation](https://hackage.haskell.org/package/YamlReference)


### PR DESCRIPTION
No reason to write it out ourselves. I replaced the existing wording with the recommended wording directly from the RFC.

Also, the old link was wrong (pointed to 2199 rather than 2119).