### PR TITLE
Fix/reformat scalar node content in the diagrams.

### DIFF
--- a/spec/tex/model2.tex
+++ b/spec/tex/model2.tex
@@ -23,12 +23,8 @@
 \entity[above right=of Tag]{+ Non-Specific Tag}{};
 \draw[inherits] (+ Non-Specific Tag) -| (Tag);
 
-\entity[below=of Node]{Scalar Node}{};
+\entity[below=of Node]{Scalar Node}{Canonical Form/\\+Formatted Content};
 \draw[inherits] (Scalar Node) -- (Node);
-
-\node[parallellogram, below=of Scalar Node](Canonical Form) {String};
-\draw[has] (Scalar Node) -- (Canonical Form)
-  node[onArrow, midway] {Canonical Form/\\++ Formatted Content};
 
 \entity[left=of Scalar Node]{Sequence Node}{};
 \draw[inherits] (Sequence Node) -- ++(0,+10mm) -| (Node);

--- a/spec/tex/present2.tex
+++ b/spec/tex/present2.tex
@@ -23,12 +23,8 @@
 \entity[above right=of Tag]{+ Non-Specific Tag}{};
 \draw[inherits] (+ Non-Specific Tag) -| (Tag);
 
-\entity[below=of Node]{Scalar Node}{};
+\entity[below=of Node]{Scalar Node}{+Formatted Content};
 \draw[inherits] (Scalar Node) -- (Node);
-
-\node[parallellogram, below=of Scalar Node](Canonical Form) {String};
-\draw[has] (Scalar Node) -- (Canonical Form)
-  node[onArrow, midway] {++ Formatted\\Content};
 
 \entity[left=of Scalar Node]{Sequence Node}{};
 \draw[inherits] (Sequence Node) -- ++(0,+10mm) -| (Node);

--- a/spec/tex/represent2.tex
+++ b/spec/tex/represent2.tex
@@ -16,12 +16,8 @@
 \entity[right=of Tag]{Specific Tag}{};
 \draw[inherits] (Specific Tag) -- (Tag);
 
-\entity[below=of Node]{Scalar Node}{};
+\entity[below=of Node]{Scalar Node}{Canonical Form};
 \draw[inherits] (Scalar Node) -- (Node);
-
-\node[parallellogram, below=of Scalar Node](Canonical Form) {String};
-\draw[has] (Scalar Node) -- (Canonical Form)
-  node[onArrow, midway] {Canonical\\Form};
 
 \entity[left=of Scalar Node]{Sequence Node}{};
 \draw[inherits] (Sequence Node) -- ++(0,+10mm) -| (Node);

--- a/spec/tex/serialize2.tex
+++ b/spec/tex/serialize2.tex
@@ -21,12 +21,8 @@
 \entity[above right=of Tag]{+ Non-Specific Tag}{};
 \draw[inherits] (+ Non-Specific Tag) -| (Tag);
 
-\entity[below=of Node]{Scalar Node}{};
+\entity[below=of Node]{Scalar Node}{+Formatted Content};
 \draw[inherits] (Scalar Node) -- (Node);
-
-\node[parallellogram, below=of Scalar Node](Canonical Form) {String};
-\draw[has] (Scalar Node) -- (Canonical Form)
-  node[onArrow, midway] {Canonical\\Form};
 
 \entity[left=of Scalar Node]{Sequence Node}{};
 \draw[inherits] (Sequence Node) -- ++(0,+10mm) -| (Node);


### PR DESCRIPTION
Notate scalar node content as an attribute of scalar nodes rather than as a separate entity. Also correctly note that scalar nodes in the serialization tree have formatted content, not content in canonical form.

![model2](https://user-images.githubusercontent.com/16958499/132046417-768f27f4-a037-4380-980e-6141589cd35b.png)