### PR TITLE
Clean up legends to remove unnecessary script.

### DIFF
--- a/tool/bin/markydown-to-kramdown
+++ b/tool/bin/markydown-to-kramdown
@@ -601,8 +601,8 @@ sub apply_highlights {
         else { $end = $col }
       }
       else { $col = 0; $end = $len }
-      $chars[$row]->[$col] =~ s{^}{[%code class="legend-$i"%]};
-      $chars[$row]->[$end] =~ s{$}{[%/code%]};
+      $chars[$row]->[$col] =~ s{^}{[%mark class="legend-$i"%]};
+      $chars[$row]->[$end] =~ s{$}{[%/mark%]};
     }
   }
 
@@ -623,7 +623,7 @@ sub apply_highlights {
     }
     next unless @re;
     my $re = '(' . join('|', @re) . ')';
-    $yaml =~ s{$re}{[%code class="legend-$i"%]${1}[%/code%]}g;
+    $yaml =~ s{$re}{[%mark class="legend-$i"%]${1}[%/mark%]}g;
   }
 
   return $yaml;
@@ -664,7 +664,7 @@ sub format_legend {
   my $i = 1;
   for (@lines) {
     if (/^\*\ /) {
-      s{^\*\ (.*)}{* <code class="legend-$i">$1</code>}g;
+      s{^\*\ (.*)}{* <mark class="legend-$i">$1</mark>}g;
       $i++;
     }
   }

--- a/tool/bin/markydown-to-kramdown
+++ b/tool/bin/markydown-to-kramdown
@@ -664,7 +664,7 @@ sub format_legend {
   my $i = 1;
   for (@lines) {
     if (/^\*\ /) {
-      s{^\*\ (.*)}{* <mark class="legend-$i">$1</mark>}g;
+      s{^\*\ (.*)}{* <code class="legend-$i">$1</code>}g;
       $i++;
     }
   }

--- a/www/build/_layouts/default.html
+++ b/www/build/_layouts/default.html
@@ -20,13 +20,6 @@
 </div>
 </main>
 
-<!-- XXX What is this for? -->
-<script>
-for (const c of document.querySelectorAll('code > code')) {
-  c.parentElement.classList.add('container');
-}
-</script>
-
 </body>
 
 </html>

--- a/www/build/_layouts/spec.html
+++ b/www/build/_layouts/spec.html
@@ -29,13 +29,6 @@ the content of this draft or cite it as an authority.
 
 </main>
 
-<!-- XXX What is this for? -->
-<script>
-for (const c of document.querySelectorAll('code > code')) {
-  c.parentElement.classList.add('container');
-}
-</script>
-
 </body>
 
 </html>

--- a/www/src/spec.scss
+++ b/www/src/spec.scss
@@ -63,11 +63,10 @@ div.legend, pre {
   mark {
     border-radius: 0.3rem;
     box-shadow: 0 0 0 1px #666 inset;
-    padding: 2px 4px;
+    padding: 2px 0;
 
     mark {
-      padding-top: 0;
-      padding-bottom: 0;
+      padding: 0;
     }
   }
 }

--- a/www/src/spec.scss
+++ b/www/src/spec.scss
@@ -63,11 +63,12 @@ div.legend, pre {
   mark {
     border-radius: 0.3rem;
     box-shadow: 0 0 0 1px #666 inset;
-    padding: 3px 0;
     color: inherit;
+    display: inline-block;
+    line-height: 16px;
 
     mark {
-      padding: 0;
+      margin: 3px 0;
     }
   }
 }

--- a/www/src/spec.scss
+++ b/www/src/spec.scss
@@ -72,10 +72,10 @@ div.legend, pre {
   }
 }
 
-.legend-1 { background-color: #F8F8E0; }
-.legend-2 { background-color: #E0E0F8; }
-.legend-3 { background-color: #F8E0F8; }
-.legend-4 { background-color: #E0F8F8; }
+.legend-1 { background-color: #F8F8E0 !important; }
+.legend-2 { background-color: #E0E0F8 !important; }
+.legend-3 { background-color: #F8E0F8 !important; }
+.legend-4 { background-color: #E0F8F8 !important; }
 
 div.legend {
   margin-left: 1rem;
@@ -97,6 +97,10 @@ div.legend {
       display: inline;
       white-space: nowrap;
     }
+  }
+
+  code {
+    box-shadow: 0 0 0 1px #666 inset;
   }
 }
 

--- a/www/src/spec.scss
+++ b/www/src/spec.scss
@@ -59,31 +59,23 @@ pre.example {
   border-left: none;
 }
 
-code.container {
-  padding-top: 3px !important;
-  padding-bottom: 3px !important;
-}
+div.legend, pre {
+  mark {
+    border-radius: 0.3rem;
+    box-shadow: 0 0 0 1px #666 inset;
+    padding: 2px 4px;
 
-div.legend > *, pre {
-  code {
-    &.legend-1 {
-      background-color: #F8F8E0;
-      box-shadow: 0 0 0 1px #666 inset;
-    }
-    &.legend-2 {
-      background-color: #E0E0F8;
-      box-shadow: 0 0 0 1px #666 inset;
-    }
-    &.legend-3 {
-      background-color: #F8E0F8;
-      box-shadow: 0 0 0 1px #666 inset;
-    }
-    &.legend-4 {
-      background-color: #E0F8F8;
-      box-shadow: 0 0 0 1px #666 inset;
+    mark {
+      padding-top: 0;
+      padding-bottom: 0;
     }
   }
 }
+
+.legend-1 { background-color: #F8F8E0; }
+.legend-2 { background-color: #E0E0F8; }
+.legend-3 { background-color: #F8E0F8; }
+.legend-4 { background-color: #E0F8F8; }
 
 div.legend {
   margin-left: 1rem;

--- a/www/src/spec.scss
+++ b/www/src/spec.scss
@@ -63,7 +63,8 @@ div.legend, pre {
   mark {
     border-radius: 0.3rem;
     box-shadow: 0 0 0 1px #666 inset;
-    padding: 2px 0;
+    padding: 3px 0;
+    color: inherit;
 
     mark {
       padding: 0;

--- a/www/src/spec.scss
+++ b/www/src/spec.scss
@@ -66,10 +66,8 @@ div.legend, pre {
     color: inherit;
     display: inline-block;
     line-height: 16px;
+    padding: 3px 0 !important;
 
-    mark {
-      margin: 3px 0 !important;
-    }
   }
 }
 

--- a/www/src/spec.scss
+++ b/www/src/spec.scss
@@ -68,7 +68,7 @@ div.legend, pre {
     line-height: 16px;
 
     mark {
-      margin: 3px 0;
+      margin: 3px 0 !important;
     }
   }
 }


### PR DESCRIPTION
Use `<mark>` instead of `<code>`, which a) is more semantically appropriate and b) isn't styled by the theme. This removes the need for the `.container` class, the script that applies it, and several `!important` rules.