### PR TITLE
Fix and improve tags in model diagrams

### DIFF
--- a/spec/tex/model2.tex
+++ b/spec/tex/model2.tex
@@ -12,16 +12,16 @@
   Line Wrapping…
 };
 
-\entity[above=of Node]{Tag}{Name\\Kind};
+\entity[above=of Node]{Tag}{Name};
 \draw[has] (Node) -- (Tag)
-  node[near start, right]{1}
-  node[near end, right]{*};
+  node[near start, left]{1}
+  node[near end, left]{*};
 
-\entity[right=of Tag]{Scalar Tag}{Canonical Format};
-\draw[inherits] (Scalar Tag) -- (Tag);
+\entity[right=of Tag]{Specific Tag}{};
+\draw[inherits] (Specific Tag) -- (Tag);
 
-\entity[above right=of Tag]{++ Non-Specific Tag}{};
-\draw[inherits] (++ Non-Specific Tag) -| (Tag);
+\entity[above right=of Tag]{+ Non-Specific Tag}{};
+\draw[inherits] (+ Non-Specific Tag) -| (Tag);
 
 \entity[below=of Node]{Scalar Node}{};
 \draw[inherits] (Scalar Node) -- (Node);

--- a/spec/tex/present2.tex
+++ b/spec/tex/present2.tex
@@ -12,13 +12,16 @@
   Line Wrapping…
 };
 
-\entity[above=of Node]{Tag}{Name\\Kind};
+\entity[above=of Node]{Tag}{Name};
 \draw[has] (Node) -- (Tag)
-  node[near start, right]{1}
-  node[near end, right]{*};
+  node[near start, left]{1}
+  node[near end, left]{*};
 
-\entity[right=of Tag]{++ Non-Specific Tag}{};
-\draw[inherits] (++ Non-Specific Tag) -- (Tag);
+\entity[right=of Tag]{Specific Tag}{};
+\draw[inherits] (Specific Tag) -- (Tag);
+
+\entity[above right=of Tag]{+ Non-Specific Tag}{};
+\draw[inherits] (+ Non-Specific Tag) -| (Tag);
 
 \entity[below=of Node]{Scalar Node}{};
 \draw[inherits] (Scalar Node) -- (Node);

--- a/spec/tex/represent2.tex
+++ b/spec/tex/represent2.tex
@@ -8,13 +8,13 @@
 
 \entity{Node}{};
 
-\entity[above=of Node]{Tag}{Name\\Kind};
+\entity[above=of Node]{Tag}{Name};
 \draw[has] (Node) -- (Tag)
-  node[near start, right]{1}
-  node[near end, right]{*};
+  node[near start, left]{1}
+  node[near end, left]{*};
 
-\entity[right=of Tag]{Scalar Tag}{Canonical Format};
-\draw[inherits] (Scalar Tag) -- (Tag);
+\entity[right=of Tag]{Specific Tag}{};
+\draw[inherits] (Specific Tag) -- (Tag);
 
 \entity[below=of Node]{Scalar Node}{};
 \draw[inherits] (Scalar Node) -- (Node);

--- a/spec/tex/serialize2.tex
+++ b/spec/tex/serialize2.tex
@@ -10,13 +10,16 @@
   +Anchor
 };
 
-\entity[above=of Node]{Tag}{Name\\Kind};
+\entity[above=of Node]{Tag}{Name};
 \draw[has] (Node) -- (Tag)
-  node[near start, right]{1}
-  node[near end, right]{*};
+  node[near start, left]{1}
+  node[near end, left]{*};
 
-\entity[right=of Tag]{Scalar Tag}{Canonical Format};
-\draw[inherits] (Scalar Tag) -- (Tag);
+\entity[right=of Tag]{Specific Tag}{};
+\draw[inherits] (Specific Tag) -- (Tag);
+
+\entity[above right=of Tag]{+ Non-Specific Tag}{};
+\draw[inherits] (+ Non-Specific Tag) -| (Tag);
 
 \entity[below=of Node]{Scalar Node}{};
 \draw[inherits] (Scalar Node) -- (Node);


### PR DESCRIPTION
This PR fixes some tag-related errors in the model diagrams:

- The diagram labeled all specific tags as scalar tags, which is incorrect.
- The diagram restricted the serialization tree to specific tags and the presentation model to non-specific tags, but either sort of tag is allowed in either model. (The representation graph only allows specific tags.)
- The diagram referred to both the kind of a tag and the canonical form of a specific tag, but these are not properly part of any of the information models.

The PR also moves the `*` and `1` on the arrow from Node to Tag to the left side of that arrow, for legibility reasons.

Arguably, we should go a bit further and clarify that Nodes in the presentation model have tag *properties*, not tags, and that tag properties are optional, but this might be overkill.

