### PR TITLE
Markdown formatting tool and test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 include tool/make/init.mk
 
+ifdef test
+TEST_FILES := $(test)
+else
 TEST_FILES := $(wildcard test/test-*)
+endif
 
 default:
 
@@ -9,6 +13,9 @@ docker-build-all docker-push-all docker-pull-all:
 
 build html site serve publish publish-fork force diff:
 	$(MAKE) -C www $@
+
+format:
+	$(MAKE) -C $(SPEC) $@
 
 test: test-spec $(TEST_FILES)
 

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,7 @@ build html site serve publish publish-fork force diff:
 format:
 	$(MAKE) -C $(SPEC) $@
 
-test: test-spec $(TEST_FILES)
-
-test-spec:
-	$(MAKE) -C spec test
+test: $(TEST_FILES)
 
 $(TEST_FILES): force
 	bash $@

--- a/spec/Makefile
+++ b/spec/Makefile
@@ -15,6 +15,10 @@ build: build-img
 test:
 	check-spec-file $(ALL_CHECK:check-%=%)
 
+format: spec.md
+	format-markdown $< > /tmp/spec.md
+	mv /tmp/spec.md $<
+
 clean:
 	rm -fr img html build
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -8,8 +8,7 @@ status: draft
 
 **YAML Specification Version 1.2.1 -- Released YYYY-MM-DD**
 
-Copyright presently by [The YAML Language Development Team](
-core-team)  
+Copyright presently by [The YAML Language Development Team](core-team)  
 Copyright 2001-2009 by Oren Ben-Kiki, Clark Evans, Ingy döt Net
 
 This document may be freely copied, provided it is not modified.
@@ -95,8 +94,8 @@ information and the rest containing the data itself.
 YAML achieves a unique cleanness by minimizing the amount of structural
 characters and allowing the data to show itself in a natural and meaningful
 way.
-For example, [indentation] may be used for structure, [colons] separate
-[key: value pairs] and [dashes] are used to create "bullet" [lists].
+For example, [indentation] may be used for structure, [colons] separate [key:
+value pairs] and [dashes] are used to create "bullet" [lists].
 
 There are myriad flavors of [data structures], but they can all be adequately
 [represented] with three basic primitives: [mappings] (hashes/dictionaries),
@@ -144,8 +143,8 @@ YAML integrates and builds upon concepts described by C[^C], Java[^Java],
 Perl[^Perl], Python[^Python], Ruby[^Ruby], Email[^Email], HTML[^HTML],
 MIME[^MIME], URIs[^URI], XML[^XML], SAX[^SAX], SOAP[^SOAP] and JSON[^JSON].
 
-The syntax of YAML was motivated by Internet Mail (Email) and remains
-partially compatible with that standard.
+The syntax of YAML was motivated by Internet Mail (Email) and remains partially
+compatible with that standard.
 Further, borrowing from MIME, YAML's top-level production is a [stream] of
 independent [documents], ideal for message-based distributed processing
 systems.
@@ -468,8 +467,8 @@ the [dash], [colon] or [question mark].
 
 ## #. Scalars
 
-[Scalar content] can be written in [block] notation, using a [literal
-style] (indicated by ["**`|`**"]) where all [line breaks] are significant.
+[Scalar content] can be written in [block] notation, using a [literal style]
+(indicated by ["**`|`**"]) where all [line breaks] are significant.
 Alternatively, they can be written with the [folded style] [(denoted by
 "**`>`**"]) where each [line break] is [folded] to a [space] unless it ends an
 [empty] or a [more-indented] line.
@@ -822,8 +821,8 @@ The [scalar] represents strings, integers, dates and other atomic data types.
 specifying its data type.
 Type specifiers are either [global] URIs or are [local] in scope to a single
 [application].
-For example, an integer is represented in YAML with a [scalar] plus the
-[global tag] "**`tag:yaml.org,2002:int`**".
+For example, an integer is represented in YAML with a [scalar] plus the [global
+tag] "**`tag:yaml.org,2002:int`**".
 Similarly, an invoice object, particular to a given organization, could be
 represented as a [mapping] together with the [local tag] "**`!invoice`**".
 This simple model can represent any data structure independent of programming
@@ -878,8 +877,8 @@ Parsing can fail due to [ill-formed] input.
 
 ? Composing the Representation Graph
 
-: _Composing_ takes a [serialization tree] and produces a
-[representation graph].
+: _Composing_ takes a [serialization tree] and produces a [representation
+graph].
 Composing discards all the [details] introduced in the [serialization] process,
 producing only the [representation graph].
 Composing can fail due to any of several reasons, detailed [below].
@@ -1038,9 +1037,9 @@ duplicate [key] as an error.
 
 ? Canonical Form
 
-: YAML supports the need for [scalar] equality by requiring that every
-[scalar] [tag] must specify a mechanism for producing the _canonical form_ of
-any [formatted content].
+: YAML supports the need for [scalar] equality by requiring that every [scalar]
+[tag] must specify a mechanism for producing the _canonical form_ of any
+[formatted content].
 This form is a Unicode character string which also [presents] the same
 [content] and can be used for equality testing.
 While this requirement is stronger than a well defined equality operator, it
@@ -1513,8 +1512,8 @@ characters inside [quoted scalars].
 To ensure readability, non-printable characters should be [escaped] on output,
 even inside such [scalars].
 
-> Note: JSON [quoted scalars] cannot span multiple lines or contain [tabs],
-but YAML [quoted scalars] can.
+> Note: JSON [quoted scalars] cannot span multiple lines or contain [tabs], but
+YAML [quoted scalars] can.
 
 ```
 [#] nb-json ::=
@@ -1835,8 +1834,7 @@ flow scalar].
 ```
 
 
-["**`"`**"] (**`#x22`**, double quote) surrounds a [double-quoted flow
-scalar].
+["**`"`**"] (**`#x22`**, double quote) surrounds a [double-quoted flow scalar].
 
 ```
 [#] c-double-quote ::= """
@@ -1892,6 +1890,7 @@ grave accent) are _reserved_ for future use.
 
 
 **Example #. Invalid use of Reserved Indicators**
+
 ```
 commercial-at: @text
 grave-accent: `text
@@ -3336,6 +3335,7 @@ valid URI (a [global tag]).
 
 
 **Example #. Verbatim Tags**
+
 ```
 !<tag:yaml.org,2002:str> foo :
   !<!bar> baz
@@ -3540,8 +3540,8 @@ Second occurrence: *anchor
 
 YAML's _flow styles_ can be thought of as the natural extension of JSON to
 cover [folding] long content lines for readability, [tagging] nodes to control
-[construction] of [native data structures] and using [anchors] and [aliases]
-to reuse [constructed] object instances.
+[construction] of [native data structures] and using [anchors] and [aliases] to
+reuse [constructed] object instances.
 
 
 ## #. Alias Nodes
@@ -4598,6 +4598,7 @@ nodes] which refer to the [anchored] [node properties].
 
 
 **Example #. Flow Nodes**
+
 ```
 - !!str "a"
 - 'b'
@@ -6026,6 +6027,7 @@ tuple and Java's array or Vector.
 
 
 **Example #. `!!seq` Examples**
+
 ```
 Block style: !!seq
 - Clark Evans
@@ -6359,6 +6361,7 @@ string).
 
 
 **Example #. Core Tag Resolution**
+
 ```
 A null: null
 Also a null: # Empty

--- a/test/setup
+++ b/test/setup
@@ -30,3 +30,5 @@ end() (
 )
 
 trap end exit
+
+trap 'exit 1' int

--- a/test/setup
+++ b/test/setup
@@ -15,6 +15,11 @@ G=$'\e[0;32m'
 Y=$'\e[0;33m'
 Z=$'\e[0m'
 
+die() (
+  echo "$R$*$Z" >&2
+  exit 1
+)
+
 end() (
   if [[ $? -eq 0 ]]; then
     echo "${G}PASSED$Z '$Y$test_file$Z'"

--- a/test/test-format-markdown.sh
+++ b/test/test-format-markdown.sh
@@ -1,0 +1,9 @@
+
+#!/usr/bin/env bash
+
+source "$(cd "$(dirname ${BASH_SOURCE[0]})" && pwd)/setup"
+
+( set -x; format-markdown ../spec/spec.md > /tmp/spec.md )
+
+( set -x; diff -u ../spec/spec.md /tmp/spec.md) ||
+  die "spec.md not properly formatted"

--- a/test/test-format-markdown.sh
+++ b/test/test-format-markdown.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 
 source "$(cd "$(dirname ${BASH_SOURCE[0]})" && pwd)/setup"

--- a/test/test-line-wrap.sh
+++ b/test/test-line-wrap.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+source "$(cd "$(dirname ${BASH_SOURCE[0]})" && pwd)/setup"
+
+# TODO check all markdown files
+# for file in ../spec/*.md; do
+
+for file in ../spec/spec.md; do
+  tmp=/tmp/$(basename "$file")
+  (set -x; format-markdown "$file" > "$tmp")
+  (set -x; diff -u "$file" "$tmp")
+done

--- a/tool/bin/format-markdown
+++ b/tool/bin/format-markdown
@@ -1,0 +1,154 @@
+#!/usr/bin/env perl
+
+use v5.18;
+
+# use XXX;
+# use utf8;
+use Encode qw(decode encode);
+
+
+my @l = ();
+my $l = '';
+
+sub in {
+  decode('UTF-8', <>, Encode::FB_CROAK);
+}
+sub out {
+  print encode('UTF-8', $_[0], Encode::FB_CROAK);
+}
+sub peek {
+  @l and $l[0];
+}
+sub take {
+  shift(@l);
+}
+sub give {
+  unshift(@l, "$_[0]\n");
+}
+sub space {
+  out take while peek =~ /^$/;
+  return 1;
+}
+sub lines {
+  while ($l) {
+    if (length $l <= 79) {
+      out "$l\n";
+      last;
+    }
+    elsif ($l =~ s{^(.{5,77}\ \ )$/}{}) {
+      out "$1\n";
+    }
+    elsif ($l =~ s{^(\S.{10,77}\S)(?:$|\ (?=\S))}{}) {
+      out "$1\n";
+    }
+    else {
+      die ">>$l<<";
+    }
+  }
+}
+sub xhead {
+  my ($sub, $file, $line) = caller;
+  warn "Error from '$sub' line $line:\n";
+  my $lines = join '', @l[0..10];
+  die "$lines";
+}
+
+sub wrap {
+  my $end = shift;
+  my @l;
+  while (peek =~ /./) {
+    my $line = take;
+    chomp $line;
+    push @l, $line;
+    last if $line =~ /(  |\.)$/;
+    last if $end->();
+  }
+  $l = join ' ', @l;
+  $l =~ s{\]\(\ }{](};
+  lines;
+  space;
+  return 1;
+}
+
+sub line {
+  out take;
+}
+
+sub para {
+  my $end = sub { 0 };
+  wrap $end;
+}
+
+sub list {
+  my $end = sub { peek =~ /^(?:\*\ |$)/ };
+  wrap($end);
+}
+
+sub toc {
+  line;
+  line;
+  space;
+}
+
+sub pre {
+  line;
+  line while peek !~ /^\`\`\`$/;
+  line;
+  line while peek =~ /^<!-- .* -->$/;
+  space;
+}
+
+sub tabl {
+  line while peek =~ /^\|\ /;
+  space;
+}
+
+sub leg {
+  line;
+  line while peek =~ /^\*\ /;
+  space;
+}
+
+sub comm {
+  my $line = take;
+  out $line;
+  if ($line !~ /-->/) {
+    while (peek !~ /-->$/) {
+      out take;
+    }
+  }
+  space;
+}
+
+#------------------------------------------------------------------------------
+sub main {
+  push @l, $_ while $_ = in;
+
+  if (peek =~ /^---$/) {
+    out take;
+    out take while peek !~ /^---$/;
+    out take;
+    space;
+  }
+
+  while (my $peek = peek) {
+    line and next if $peek =~ /^\[\^/;
+    leg  and next if $peek =~ /^\*\*Legend:\*\*$/;
+    toc  and next if $peek =~ /^\{:toc\}$/;
+    pre  and next if $peek =~ /^\`\`\`$/;
+    list and next if $peek =~ /^\*\ /;
+    tabl and next if $peek =~ /^\|\ /;
+    comm and next if $peek =~ /^<--/;
+    para and next if $peek =~ /^(
+      [\w\#\*"] |
+      \[\w |
+      \!\[ |
+      \(\w |
+      [\?\:\>]\ |
+      \[\"\*\* |
+    )/x;
+    xhead;
+  }
+}
+
+main(@ARGV);

--- a/tool/bin/format-markdown
+++ b/tool/bin/format-markdown
@@ -2,10 +2,7 @@
 
 use v5.18;
 
-# use XXX;
-# use utf8;
 use Encode qw(decode encode);
-
 
 my @l = ();
 my $l = '';
@@ -45,12 +42,6 @@ sub lines {
       die ">>$l<<";
     }
   }
-}
-sub xhead {
-  my ($sub, $file, $line) = caller;
-  warn "Error from '$sub' line $line:\n";
-  my $lines = join '', @l[0..10];
-  die "$lines";
 }
 
 sub wrap {
@@ -120,6 +111,15 @@ sub comm {
   space;
 }
 
+sub unknown {
+  my $line = take;
+  my $show = $line;
+  chomp $show;
+  warn "Unrecognized line: >>$show<<\n";
+  out $line;
+  space;
+}
+
 #------------------------------------------------------------------------------
 sub main {
   push @l, $_ while $_ = in;
@@ -138,16 +138,17 @@ sub main {
     pre  and next if $peek =~ /^\`\`\`$/;
     list and next if $peek =~ /^\*\ /;
     tabl and next if $peek =~ /^\|\ /;
-    comm and next if $peek =~ /^<--/;
+    comm and next if $peek =~ /^<!--/;
     para and next if $peek =~ /^(
       [\w\#\*"] |
       \[\w |
       \!\[ |
       \(\w |
       [\?\:\>]\ |
-      \[\"\*\* |
+      \[\"\*\*
     )/x;
-    xhead;
+
+    unknown;
   }
 }
 


### PR DESCRIPTION
Now `make format` will reformat the `spec.md` file, and wrap all the lines appropriately.

A new test in the cicd suite makes sure the spec.md is properly formatted.