### PR TITLE
Define upcoming spec version as v1.2.2

### DIFF
--- a/spec/spec-authors.md
+++ b/spec/spec-authors.md
@@ -1,9 +1,9 @@
 # YAML Specification Authors
 
 The current version of the YAML language is **1.2** and the current YAML
-specification version is **1.2.1**.
+specification version is **1.2.2**.
 
-# v1.2.1 Primary Authors
+# v1.2.2 Primary Authors
 
 * Ingy döt Net —
   [@ingydotnet](https://github.com/ingydotnet)
@@ -17,4 +17,4 @@ specification version is **1.2.1**.
   [@Thom1729](https://github.com/thom1729)
 
 See the specification [change history](
-https://github.com/yaml/yaml-spec/releases/tag/v1.2.1) for full details.
+https://github.com/yaml/yaml-spec/releases/tag/v1.2.2) for full details.

--- a/spec/spec-changes.md
+++ b/spec/spec-changes.md
@@ -1,9 +1,9 @@
 # YAML Specification Changes
 
 The current version of the YAML language is **1.2** and the current YAML
-specification version is **1.2.1**.
+specification version is **1.2.2**.
 
-## Changes in v1.2.1 (YYYY-MM-DD)
+## Changes in v1.2.2 (YYYY-MM-DD)
 
 * Host the YAML specification sources in a [public repository^]
 * Change the source format from DocBook to Markdown
@@ -14,7 +14,11 @@ specification version is **1.2.1**.
 * Fixed known bugs in the grammar productions
 * More TODO
 
-## Changes in v1.2 (2009-10-01)
+## Changes in v1.2.1 (2009-10-01)
+
+* TODO
+
+## Changes in v1.2.0 (2009-07-21)
 
 * TODO
 

--- a/spec/spec-errata.md
+++ b/spec/spec-errata.md
@@ -1,3 +1,3 @@
-# YAML Specification 1.2.1 Errata
+# YAML Specification 1.2.2 Errata
 
 * None yet reported

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -6,7 +6,7 @@ status: draft
 
 # YAML Ain't Markup Language (YAML™) Version 1.2
 
-**YAML Specification Version 1.2.1 -- Released YYYY-MM-DD**
+**YAML Specification Version 1.2.2 -- Released YYYY-MM-DD**
 
 Copyright presently by [The YAML Language Development Team](core-team)  
 Copyright 2001-2009 by Oren Ben-Kiki, Clark Evans, Ingy döt Net
@@ -16,7 +16,7 @@ This document may be freely copied, provided it is not modified.
 
 **Status of this Document**
 
-This is the **YAML specification v1.2.1**.
+This is the **YAML specification v1.2.2**.
 It defines the **YAML 1.2 data language**.
 There are no normative changes from the **YAML specification v1.2**.
 The primary objectives of this version are to correct errors and add clarity.
@@ -53,9 +53,9 @@ See:
 * [YAML Implementer's Reference Index](implementer-refs)
 * [YAML User's Reference Index](user-refs)
 * [YAML Community](community)
-* [YAML 1.2.1 Specification Errata](spec-errata)
-* [YAML 1.2.1 Specification Changes](spec-changes)
-* [YAML 1.2.1 Specification Authors](spec-authors)
+* [YAML 1.2.2 Specification Errata](spec-errata)
+* [YAML 1.2.2 Specification Changes](spec-changes)
+* [YAML 1.2.2 Specification Authors](spec-authors)
 
 
 **Abstract**
@@ -168,7 +168,7 @@ In 2020, the new [YAML language design team](core-team) began meeting regularly
 to discuss improvements to the YAML language and specification; to better meet
 the needs and expectations of its users and use cases.
 
-This YAML 1.2.1 specification, published in September 2021, is the first step
+This YAML 1.2.2 specification, published in September 2021, is the first step
 in YAML's rejuvenated development journey.
 YAML is now more popular than it has ever been, but there is a long list of
 things that need to be addressed for it to reach its full potential.

--- a/www/main/index.md
+++ b/www/main/index.md
@@ -3,7 +3,7 @@ YAML Specification Development
 
 * [YAML 1.2 Spec - from Markdown](spec)
   * [Compare to DocBook Version](review)
-* [YAML 1.2.1 Spec](spec) (draft)
+* [YAML 1.2.2 Spec](spec) (draft)
   * [Compare to new 1.2](review)
   * [Compare to old 1.2](review)
 * [YAML Developers Documentation](doc)


### PR DESCRIPTION
With this understanding, the 1.2.0 spec version was published on 2009-07-21, and patched in 1.2.1 on 2009-10-01; that's the current latest published version.