### PR TITLE
Fix Example "9.5 Directives Documents"

### DIFF
--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -5740,7 +5740,7 @@ A _directives document_ begins with some [directives] followed by an explicit
 --- |
 %!PS-Adobe-2.0
 ...
-%YAML1.2
+%YAML 1.2
 ---
 # Empty
 ...


### PR DESCRIPTION
Add missing space before `1.2`

See also https://github.com/yaml/yaml/issues/19