### PR TITLE
Fix typo under 6.8.2.2. Tag Prefixes

### DIFF
--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -3137,7 +3137,7 @@ semantics to the same [local tag].
 valid URI prefix, and should contain at least the scheme.
 [Shorthands] using the associated [handle] are expanded to globally unique URI
 tags and their semantics is consistent across [applications].
-In particular, every [documents] in every [stream] must assign the same
+In particular, every [document] in every [stream] must assign the same
 semantics to the same [global tag].
 
 ```

--- a/tool/make/init.mk
+++ b/tool/make/init.mk
@@ -21,7 +21,7 @@ endif
 ROOT := $(YAML_SPEC_ROOT)
 
 SPEC12 := $(ROOT)/1.2
-SPEC := $(ROOT)/spec
+SPEC := $(ROOT)/spec/1.2.2
 DOC := $(ROOT)/doc
 GRAMMAR := $(ROOT)/grammar
 RFC := $(ROOT)/rfc


### PR DESCRIPTION
See also https://github.com/yaml/yaml/issues/46