### PR TITLE
Production formatting

### DIFF
--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -1972,7 +1972,8 @@ YAML recognizes two _white space_ characters: _space_ and _tab_.
 ```
 [#] s-white ::=
   ( s-space
-  | s-tab )
+  | s-tab
+  )
 ```
 
 
@@ -2087,7 +2088,8 @@ YAML [stream], without any processing.
   | '('
   | ')'
   | '['
-  | ']' )
+  | ']'
+  )
 ```
 
 
@@ -2154,7 +2156,8 @@ tab to become part of the [content].
 ```
 [#] ns-esc-horizontal-tab ::=
   ( 't'
-  | x09 )
+  | x09
+  )
 ```
 
 
@@ -2282,7 +2285,7 @@ Any escaped character:
 
 ```
 [#] c-ns-esc-char ::=
-  '\'
+  c-escape         # '\'
   ( ns-esc-null
   | ns-esc-bell
   | ns-esc-backspace
@@ -2302,7 +2305,8 @@ Any escaped character:
   | ns-esc-paragraph-separator
   | ns-esc-8-bit
   | ns-esc-16-bit
-  | ns-esc-32-bit )
+  | ns-esc-32-bit
+  )
 ```
 
 
@@ -2547,7 +2551,8 @@ break].
 ```
 [#] l-empty(n,c) ::=
   ( s-line-prefix(n,c)
-  | s-indent(<n) )
+  | s-indent(<n)
+  )
   b-as-line-feed
 ```
 
@@ -2604,7 +2609,8 @@ A folded non-[empty line] may end with either of the above [line breaks].
 ```
 [#] b-l-folded(n,c) ::=
   ( b-l-trimmed(n,c)
-  | b-as-space )
+  | b-as-space
+  )
 ```
 
 
@@ -2725,7 +2731,7 @@ However, as this confuses many tools, YAML [processors] should terminate the
 
 ```
 [#] c-nb-comment-text ::=
-  '#'
+  c-comment    # '#'
   nb-char*
 ```
 
@@ -2888,10 +2894,11 @@ information.
 
 ```
 [#] l-directive ::=
-  '%'
+  c-directive            # '%'
   ( ns-yaml-directive
   | ns-tag-directive
-  | ns-reserved-directive )
+  | ns-reserved-directive
+  )
   s-l-comments
 ```
 
@@ -3083,7 +3090,8 @@ There are three tag handle variants:
 [#] c-tag-handle ::=
   ( c-named-tag-handle
   | c-secondary-tag-handle
-  | c-primary-tag-handle )
+  | c-primary-tag-handle
+  )
 ```
 
 
@@ -3172,9 +3180,9 @@ In particular, the YAML [processor] need not preserve the handle name once
 
 ```
 [#] c-named-tag-handle ::=
-  '!'
+  c-tag            # '!'
   ns-word-char+
-  '!'
+  c-tag            # '!'
 ```
 
 
@@ -3201,7 +3209,8 @@ There are two _tag prefix_ variants:
 ```
 [#] ns-tag-prefix ::=
   ( c-ns-local-tag-prefix
-  | ns-global-tag-prefix )
+  | ns-global-tag-prefix
+  )
 ```
 
 
@@ -3216,7 +3225,7 @@ semantics to the same [local tag].
 
 ```
 [#] c-ns-local-tag-prefix ::=
-  '!'
+  c-tag           # '!'
   ns-uri-char*
 ```
 
@@ -3325,7 +3334,8 @@ A tag is denoted by the _"**`!`**" indicator_.
 [#] c-ns-tag-property ::=
   ( c-verbatim-tag
   | c-ns-shorthand-tag
-  | c-non-specific-tag )
+  | c-non-specific-tag
+  )
 ```
 
 
@@ -3508,7 +3518,7 @@ it is valid for all [nodes] to be anchored.
 
 ```
 [#] c-ns-anchor-property ::=
-  '&'
+  c-anchor          # '&'
   ns-anchor-name
 ```
 
@@ -3580,7 +3590,7 @@ these were already specified at the first occurrence of the [node].
 
 ```
 [#] c-ns-alias-node ::=
-  '*'
+  c-alias           # '*'
   ns-anchor-name
 ```
 
@@ -3695,8 +3705,8 @@ characters.
 [#] nb-double-char ::=
   ( c-ns-esc-char
   | ( nb-json
-    - '\'
-    - '"'
+    - c-escape          # '\'
+    - c-double-quote    # '"'
     )
   )
 ```
@@ -3714,9 +3724,9 @@ Double-quoted scalars are restricted to a single line when contained inside an
 
 ```
 [#] c-double-quoted(n,c) ::=
-  '"'
+  c-double-quote         # '"'
   nb-double-text(n,c)
-  '"'
+  c-double-quote         # '"'
 ```
 
 ```
@@ -3762,7 +3772,7 @@ double-quoted lines to be broken at arbitrary positions.
 ```
 [#] s-double-escaped(n) ::=
   s-white*
-  '\'
+  c-escape         # '\'
   b-non-content
   l-empty(n,flow-in)*
   s-flow-line-prefix(n)
@@ -3771,7 +3781,8 @@ double-quoted lines to be broken at arbitrary positions.
 ```
 [#] s-double-break(n) ::=
   ( s-double-escaped(n)
-  | s-flow-folded(n) )
+  | s-flow-folded(n)
+  )
 ```
 
 
@@ -3812,7 +3823,8 @@ Empty lines, if any, are consumed as part of the [line folding].
   s-double-break(n)
   ( ns-double-char nb-ns-double-in-line
     ( s-double-next-line(n)
-    | s-white* )
+    | s-white*
+    )
   )?
 ```
 
@@ -3820,7 +3832,8 @@ Empty lines, if any, are consumed as part of the [line folding].
 [#] nb-double-multi-line(n) ::=
   nb-ns-double-in-line
   ( s-double-next-line(n)
-  | s-white* )
+  | s-white*
+  )
 ```
 
 
@@ -3860,7 +3873,7 @@ In addition, it is only possible to break a long single-quoted line where a
 [#] nb-single-char ::=
   ( c-quoted-quote
   | ( nb-json
-    - "'"
+    - c-single-quote    # "'"
     )
   )
 ```
@@ -3892,9 +3905,9 @@ Single-quoted scalars are restricted to a single line when contained inside a
 
 ```
 [#] c-single-quoted(n,c) ::=
-  "'"
+  c-single-quote    # "'"
   nb-single-text(n,c)
-  "'"
+  c-single-quote    # "'"
 ```
 
 ```
@@ -3948,7 +3961,8 @@ Empty lines, if any, are consumed as part of the [line folding].
   ( ns-single-char
     nb-ns-single-in-line
     ( s-single-next-line(n)
-    | s-white* )
+    | s-white*
+    )
   )?
 ```
 
@@ -3956,7 +3970,8 @@ Empty lines, if any, are consumed as part of the [line folding].
 [#] nb-single-multi-line(n) ::=
   nb-ns-single-in-line
   ( s-single-next-line(n)
-  | s-white* )
+  | s-white*
+  )
 ```
 
 
@@ -4000,10 +4015,9 @@ causes no ambiguity.
   ( ( ns-char
     - c-indicator
     )
-  | (
-      ( '?'
-      | ':'
-      | '-'
+  | ( ( c-mapping-key       # '?'
+      | c-mapping-value     #':'
+      | c-sequence-entry    #'-'
       )
       /* Followed by an ns-plain-safe(c) */
     )
@@ -4043,13 +4057,13 @@ These characters would cause ambiguity with [flow collection] structures.
 ```
 [#] ns-plain-char(c) ::=
   ( ( ns-plain-safe(c)
-    - ':'
-    - '#'
+    - c-mapping-value    # ':'
+    - c-comment          # '#'
     )
   | ( /* An ns-char preceding */
-      '#'
+      c-comment          # '#'
     )
-  | ( ':'
+  | ( c-mapping-value    # ':'
       /* Followed by an ns-plain-safe(c) */
     )
   )
@@ -4200,10 +4214,10 @@ characters.
 
 ```
 [#] c-flow-sequence(n,c) ::=
-  '['
+  c-sequence-start    # '['
   s-separate(n,c)?
   ns-s-flow-seq-entries(n,in-flow(c))?
-  ']'
+  c-sequence-end      # ']'
 ```
 
 
@@ -4213,7 +4227,7 @@ Sequence entries are separated by a ["**`,`**"] character.
 [#] ns-s-flow-seq-entries(n,c) ::=
   ns-flow-seq-entry(n,c)
   s-separate(n,c)?
-  ( ','
+  ( c-collect-entry     # ','
     s-separate(n,c)?
     ns-s-flow-seq-entries(n,c)?
   )?
@@ -4246,7 +4260,8 @@ sequence entry is a [mapping] with a [single key/value pair].
 ```
 [#] ns-flow-seq-entry(n,c) ::=
   ( ns-flow-pair(n,c)
-  | ns-flow-node(n,c) )
+  | ns-flow-node(n,c)
+  )
 ```
 
 
@@ -4283,10 +4298,10 @@ characters.
 
 ```
 [#] c-flow-mapping(n,c) ::=
-  '{'
+  c-mapping-start       # '{'
   s-separate(n,c)?
   ns-s-flow-map-entries(n,in-flow(c))?
-  '}'
+  c-mapping-end         # '}'
 ```
 
 
@@ -4296,7 +4311,7 @@ Mapping entries are separated by a ["**`,`**"] character.
 [#] ns-s-flow-map-entries(n,c) ::=
   ns-flow-map-entry(n,c)
   s-separate(n,c)?
-  ( ','
+  ( c-collect-entry     # ','
     s-separate(n,c)?
     ns-s-flow-map-entries(n,c)?
   )?
@@ -4328,7 +4343,7 @@ entry may be [completely empty].
 ```
 [#] ns-flow-map-entry(n,c) ::=
   (
-    ( '?'
+    ( c-mapping-key      # '?'
       s-separate(n,c)
       ns-flow-map-explicit-entry(n,c)
     )
@@ -4383,7 +4398,8 @@ indicated by the "**`:`**".
 [#] ns-flow-map-implicit-entry(n,c) ::=
   ( ns-flow-map-yaml-key-entry(n,c)
   | c-ns-flow-map-empty-key-entry(n,c)
-  | c-ns-flow-map-json-key-entry(n,c) )
+  | c-ns-flow-map-json-key-entry(n,c)
+  )
 ```
 
 ```
@@ -4392,7 +4408,8 @@ indicated by the "**`:`**".
   ( ( s-separate(n,c)?
       c-ns-flow-map-separate-value(n,c)
     )
-  | e-node )
+  | e-node
+  )
 ```
 
 ```
@@ -4403,7 +4420,7 @@ indicated by the "**`:`**".
 
 ```
 [#] c-ns-flow-map-separate-value(n,c) ::=
-  ':'
+  c-mapping-value    # ':'
   /* Not followed by an ns-plain-safe(c) */
   ( ( s-separate(n,c)
       ns-flow-node(n,c)
@@ -4451,16 +4468,18 @@ However, as this greatly reduces readability, YAML [processors] should
   ( ( s-separate(n,c)?
       c-ns-flow-map-adjacent-value(n,c)
     )
-  | e-node )
+  | e-node
+  )
 ```
 
 ```
 [#] c-ns-flow-map-adjacent-value(n,c) ::=
-  ':'
+  c-mapping-value          # ':'
   ( ( s-separate(n,c)?
       ns-flow-node(n,c)
     )
-  | e-node )
+  | e-node
+  )
 ```
 
 
@@ -4516,7 +4535,7 @@ and the syntax is identical to the general case.
 ```
 [#] ns-flow-pair(n,c) ::=
   (
-    ( '?'
+    ( c-mapping-key      # '?'
       s-separate(n,c)
       ns-flow-map-explicit-entry(n,c)
     )
@@ -4557,7 +4576,8 @@ been impossible to implement.
 [#] ns-flow-pair-entry(n,c) ::=
   ( ns-flow-pair-yaml-key-entry(n,c)
   | c-ns-flow-map-empty-key-entry(n,c)
-  | c-ns-flow-pair-json-key-entry(n,c) )
+  | c-ns-flow-pair-json-key-entry(n,c)
+  )
 ```
 
 ```
@@ -4644,13 +4664,15 @@ Even the [double-quoted style] is a superset of the JSON string format.
   ( c-flow-sequence(n,c)
   | c-flow-mapping(n,c)
   | c-single-quoted(n,c)
-  | c-double-quoted(n,c) )
+  | c-double-quoted(n,c)
+  )
 ```
 
 ```
 [#] ns-flow-content(n,c) ::=
   ( ns-flow-yaml-content(n,c)
-  | c-flow-json-content(n,c) )
+  | c-flow-json-content(n,c)
+  )
 ```
 
 
@@ -5075,7 +5097,7 @@ It is the simplest, most restricted and most readable [scalar style].
 
 ```
 [#] c-l+literal(n) ::=
-  '|'
+  c-literal                # '|'
   c-b-block-header(m,t)
   l-literal-content(n+m,t)
 ```
@@ -5163,7 +5185,7 @@ It is similar to the [literal style]; however, folded scalars are subject to
 
 ```
 [#] c-l+folded(n) ::=
-  '>'
+  c-folded                 # '>'
   c-b-block-header(m,t)
   l-folded-content(n+m,t)
 ```
@@ -5304,7 +5326,8 @@ also not [folded].
 [#] l-nb-same-lines(n) ::=
   l-empty(n,block-in)*
   ( l-nb-folded-lines(n)
-  | l-nb-spaced-lines(n) )
+  | l-nb-spaced-lines(n)
+  )
 ```
 
 ```
@@ -5418,7 +5441,7 @@ followed by a non-space character (e.g. "**`-1`**").
 
 ```
 [#] c-l-block-seq-entry(n) ::=
-  '-'
+  c-sequence-entry    # '-'
   /* Not followed by an ns-char */
   s-l+block-indented(n,block-in)
 ```
@@ -5456,7 +5479,8 @@ Note that it is not possible to specify [node properties] for such a
 [#] s-l+block-indented(n,c) ::=
   ( ( s-indent(m)
       ( ns-l-compact-sequence(n+1+m)
-      | ns-l-compact-mapping(n+1+m) )
+      | ns-l-compact-mapping(n+1+m)
+      )
     )
   | s-l+block-node(n,c)
   | ( e-node
@@ -5537,26 +5561,28 @@ for [block sequence] entries.
 ```
 [#] ns-l-block-map-entry(n) ::=
   ( c-l-block-map-explicit-entry(n)
-  | ns-l-block-map-implicit-entry(n) )
+  | ns-l-block-map-implicit-entry(n)
+  )
 ```
 
 ```
 [#] c-l-block-map-explicit-entry(n) ::=
   c-l-block-map-explicit-key(n)
   ( l-block-map-explicit-value(n)
-  | e-node )
+  | e-node
+  )
 ```
 
 ```
 [#] c-l-block-map-explicit-key(n) ::=
-  '?'
+  c-mapping-key                      # '?'
   s-l+block-indented(n,block-out)
 ```
 
 ```
 [#] l-block-map-explicit-value(n) ::=
   s-indent(n)
-  ':'
+  c-mapping-value    # ':'
   s-l+block-indented(n,block-out)
 ```
 
@@ -5594,14 +5620,16 @@ single line and must not span more than 1024 Unicode characters.
 ```
 [#] ns-l-block-map-implicit-entry(n) ::=
   ( ns-s-block-map-implicit-key
-  | e-node )
+  | e-node
+  )
   c-l-block-map-implicit-value(n)
 ```
 
 ```
 [#] ns-s-block-map-implicit-key ::=
   ( c-s-implicit-json-key(block-key)
-  | ns-s-implicit-yaml-key(block-key) )
+  | ns-s-implicit-yaml-key(block-key)
+  )
 ```
 
 
@@ -5618,7 +5646,7 @@ This prevents a potential ambiguity with multi-line [plain scalars].
 
 ```
 [#] c-l-block-map-implicit-value(n) ::=
-  ':'
+  c-mapping-value                  # ':'
   ( s-l+block-node(n,block-out)
   | ( e-node
       s-l-comments
@@ -5694,7 +5722,8 @@ scalar] and an [implicit key] starting a nested [block mapping].
 ```
 [#] s-l+block-node(n,c) ::=
   ( s-l+block-in-block(n,c)
-  | s-l+flow-in-block(n) )
+  | s-l+flow-in-block(n)
+  )
 ```
 
 ```
@@ -5735,7 +5764,8 @@ entries.
 ```
 [#] s-l+block-in-block(n,c) ::=
   ( s-l+block-scalar(n,c)
-  | s-l+block-collection(n,c) )
+  | s-l+block-collection(n,c)
+  )
 ```
 
 ```
@@ -5745,7 +5775,8 @@ entries.
     s-separate(n+1,c)
   )?
   ( c-l+literal(n)
-  | c-l+folded(n) )
+  | c-l+folded(n)
+  )
 ```
 
 
@@ -6059,7 +6090,8 @@ following [document] must begin with a [directives end marker] line.
 [#] l-any-document ::=
   ( l-directive-document
   | l-explicit-document
-  | l-bare-document )
+  | l-bare-document
+  )
 ```
 
 ```

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -1258,6 +1258,7 @@ See for example the [**`b-break`**](#b-break) production.
 In addition, production matching is expected to be greedy.
 Optional (**`?`**), zero-or-more (**`*`**) and one-or-more (**`+`**) patterns
 are always expected to match as much of the input as possible.
+A (**`{n}`**) pattern is used to match a production exactly `n` times.
 
 The productions are accompanied by examples which are presented in a two-pane
 side-by-side format.
@@ -2185,7 +2186,7 @@ Escaped 8-bit Unicode character.
 ```
 [#] ns-esc-8-bit ::=
   'x'
-  ( ns-hex-digit × 2 )
+  ns-hex-digit{2}
 ```
 
 
@@ -2194,7 +2195,7 @@ Escaped 16-bit Unicode character.
 ```
 [#] ns-esc-16-bit ::=
   'u'
-  ( ns-hex-digit × 4 )
+  ns-hex-digit{4}
 ```
 
 
@@ -2203,7 +2204,7 @@ Escaped 32-bit Unicode character.
 ```
 [#] ns-esc-32-bit ::=
   'U'
-  ( ns-hex-digit × 8 )
+  ns-hex-digit{8}
 ```
 
 
@@ -2281,7 +2282,7 @@ convey [content] information.
 
 ```
 [#] s-indent(n) ::=
-  s-space × n
+  s-space{n}
 ```
 
 
@@ -2292,12 +2293,12 @@ to express this.
 
 ```
 [#] s-indent(<n) ::=
-  s-space × m /* Where m < n */
+  s-space{m} /* Where m < n */
 ```
 
 ```
 [#] s-indent(≤n) ::=
-  s-space × m /* Where m ≤ n */
+  s-space{m} /* Where m ≤ n */
 ```
 
 

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -1397,9 +1397,17 @@ extensive character property tables.
 
 ```
 [#] c-printable ::=
-  ( x09 | x0A | x0D | [x20-x7E]         /* 8 bit */
-  | x85 | [xA0-xD7FF] | [xE000-xFFFD]   /* 16 bit */
-  | [x010000-x10FFFF] )                 /* 32 bit */
+                         # 8 bit
+  ( x09                  # Tab (\t)
+  | x0A                  # Line feed (LF \n)
+  | x0D                  # Carriage Return (CR \r)
+  | [x20-x7E]            # Printable ASCII
+                         # 16 bit
+  | x85                  # Next Line (NEL)
+  | [xA0-xD7FF]          # Basic Multilingual Plane (BMP)
+  | [xE000-xFFFD]        # Additional Unicode Areas
+  | [x010000-x10FFFF]    # 32 bit
+  )
 ```
 
 
@@ -1413,11 +1421,13 @@ YAML [quoted scalars] can.
 
 ```
 [#] nb-json ::=
-  ( x09
-  | [x20-x10FFFF] )
+  ( x09              # Tab character
+  | [x20-x10FFFF]    # Non-C0-control characters
+  )
 ```
 
 > Note: The production name `nb-json` means "non-break JSON compatible" here.
+
 
 ## #. Character Encodings
 
@@ -1781,7 +1791,8 @@ grave accent) are _reserved_ for future use.
 ```
 [#] c-reserved ::=
   ( '@'
-  | '`' )
+  | '`'
+  )
 ```
 
 
@@ -1805,25 +1816,25 @@ Any indicator character:
 
 ```
 [#] c-indicator ::=
-  ( '-'
-  | '?'
-  | ':'
-  | ','
-  | '['
-  | ']'
-  | '{'
-  | '}'
-  | '#'
-  | '&'
-  | '*'
-  | '!'
-  | '|'
-  | '>'
-  | "'"
-  | '"'
-  | '%'
-  | '@'
-  | '`' )
+  ( c-sequence-entry    # '-'
+  | c-mapping-key       # '?'
+  | c-mapping-value     # ':'
+  | c-collect-entry     # ','
+  | c-sequence-start    # '['
+  | c-sequence-end      # ']'
+  | c-mapping-start     # '{'
+  | c-mapping-end       # '}'
+  | c-comment           # '#'
+  | c-anchor            # '&'
+  | c-alias             # '*'
+  | c-tag               # '!'
+  | c-literal           # '|'
+  | c-folded            # '>'
+  | c-single-quote      # "'"
+  | c-double-quote      # '"'
+  | c-directive         # '%'
+  | c-reserved          # '@' '`'
+  )
 ```
 
 
@@ -1835,11 +1846,12 @@ This is handled on a case-by-case basis by the relevant productions.
 
 ```
 [#] c-flow-indicator ::=
-  ( ','
-  | '['
-  | ']'
-  | '{'
-  | '}' )
+  ( c-collect-entry     # ','
+  | c-sequence-start    # '['
+  | c-sequence-end      # ']'
+  | c-mapping-start     # '{'
+  | c-mapping-end       # '}'
+  )
 ```
 
 
@@ -1859,8 +1871,9 @@ YAML recognizes the following ASCII _line break_ characters.
 
 ```
 [#] b-char ::=
-  ( b-line-feed
-  | b-carriage-return )
+  ( b-line-feed          # x0A
+  | b-carriage-return    # X0D
+  )
 ```
 
 
@@ -1882,7 +1895,7 @@ treat these line breaks as non-break characters, with an appropriate warning.
 [#] nb-char ::=
   ( c-printable
   - b-char
-  - c-byte-order-mark
+  - c-byte-order-mark      # xFEFF
   )
 ```
 
@@ -1892,10 +1905,11 @@ widely used formats.
 
 ```
 [#] b-break ::=
-  ( ( b-carriage-return
-      b-line-feed )
+  ( ( b-carriage-return    # x0A
+      b-line-feed )        # x0D
   | b-carriage-return
-  | b-line-feed )
+  | b-line-feed
+  )
 ```
 
 
@@ -2008,7 +2022,7 @@ A decimal digit for numbers:
 
 ```
 [#] ns-dec-digit ::=
-  [x30-x39]
+  [x30-x39]             # 0-9
 ```
 
 
@@ -2016,9 +2030,9 @@ A hexadecimal digit for [escape sequences]:
 
 ```
 [#] ns-hex-digit ::=
-  ( ns-dec-digit
-  | [x41-x46]
-  | [x61-x66] )
+  ( ns-dec-digit        # 0-9
+  | [x41-x46]           # A-F
+  | [x61-x66] )         # a-f
 ```
 
 
@@ -2026,8 +2040,8 @@ ASCII letter (alphabetic) characters:
 
 ```
 [#] ns-ascii-letter ::=
-  ( [x41-x5A]
-  | [x61-x7A] )
+  ( [x41-x5A]           # A-Z
+  | [x61-x7A] )         # a-z
 ```
 
 
@@ -2035,9 +2049,9 @@ Word (alphanumeric) characters for identifiers:
 
 ```
 [#] ns-word-char ::=
-  ( ns-dec-digit
-  | ns-ascii-letter
-  | '-' )
+  ( ns-dec-digit        # 0-9
+  | ns-ascii-letter     # A-Z a-z
+  | '-' )               # '-'
 ```
 
 URI characters for [tags], as defined in the URI specification[^uri].

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -1378,10 +1378,10 @@ prefixes.
 To ensure readability, YAML [streams] use only the _printable_ subset of the
 Unicode character set.
 The allowed character range explicitly excludes the C0 control block[^c0-block]
-**`#x00-#x1F`** (except for TAB **`#x09`**, LF **`#x0A`** and CR **`#x0D`**
-which are allowed), DEL **`#x7F`**, the C1 control block **`#x80-#x9F`**
-(except for NEL **`#x85`** which is allowed), the surrogate block[^surrogates]
-**`#xD800-#xDFFF`**, **`#xFFFE`** and **`#xFFFF`**.
+**`x00-x1F`** (except for TAB **`x09`**, LF **`x0A`** and CR **`x0D`** which
+are allowed), DEL **`x7F`**, the C1 control block **`x80-x9F`** (except for NEL
+**`x85`** which is allowed), the surrogate block[^surrogates]
+**`xD800-xDFFF`**, **`xFFFE`** and **`xFFFF`**.
 
 On input, a YAML [processor] must accept all characters in this printable
 subset.
@@ -1397,9 +1397,9 @@ extensive character property tables.
 
 ```
 [#] c-printable ::=
-    #x09 | #x0A | #x0D | [#x20-#x7E]       /* 8 bit */
-  | #x85 | [#xA0-#xD7FF] | [#xE000-#xFFFD] /* 16 bit */
-  | [#x010000-#x10FFFF]                    /* 32 bit */
+    x09 | x0A | x0D | [x20-x7E]       /* 8 bit */
+  | x85 | [xA0-xD7FF] | [xE000-xFFFD] /* 16 bit */
+  | [x010000-x10FFFF]                 /* 32 bit */
 ```
 
 
@@ -1413,7 +1413,7 @@ YAML [quoted scalars] can.
 
 ```
 [#] nb-json ::=
-  #x09 | [#x20-#x10FFFF]
+  x09 | [x20-x10FFFF]
 ```
 
 > Note: The production name `nb-json` means "non-break JSON compatible" here.
@@ -1423,7 +1423,7 @@ YAML [quoted scalars] can.
 All characters mentioned in this specification are Unicode code points.
 Each such code point is written as one or more bytes depending on the
 _character encoding_ used.
-Note that in UTF-16, characters above **`#xFFFF`** are written as four bytes,
+Note that in UTF-16, characters above **`xFFFF`** are written as four bytes,
 using a surrogate pair.
 
 The character encoding is a [presentation detail] and must not be used to
@@ -1436,7 +1436,7 @@ For [JSON compatibility], the UTF-32 encodings must also be supported.
 If a character [stream] begins with a _byte order mark_, the character encoding
 will be taken to be as indicated by the byte order mark.
 Otherwise, the [stream] must begin with an ASCII character.
-This allows the encoding to be deduced by the pattern of null (**`#x00`**)
+This allows the encoding to be deduced by the pattern of null (**`x00`**)
 characters.
 
 Byte order marks may appear at the start of any [document], however all
@@ -1472,7 +1472,7 @@ For more information about the byte order mark and the Unicode character
 encoding schemes see the Unicode FAQ[^uni-faq].
 
 ```
-[#] c-byte-order-mark ::= #xFEFF
+[#] c-byte-order-mark ::= xFEFF
 ```
 
 
@@ -1516,21 +1516,21 @@ ERROR:
 
 _Indicators_ are characters that have special semantics.
 
-["**`-`**"] (**`#x2D`**, hyphen) denotes a [block sequence] entry.
+["**`-`**"] (**`x2D`**, hyphen) denotes a [block sequence] entry.
 
 ```
 [#] c-sequence-entry ::= '-'
 ```
 
 
-["**`?`**"] (**`#x3F`**, question mark) denotes a [mapping key].
+["**`?`**"] (**`x3F`**, question mark) denotes a [mapping key].
 
 ```
 [#] c-mapping-key ::= '?'
 ```
 
 
-["**`:`**"] (**`#x3A`**, colon) denotes a [mapping value].
+["**`:`**"] (**`x3A`**, colon) denotes a [mapping value].
 
 ```
 [#] c-mapping-value ::= ':'
@@ -1564,35 +1564,35 @@ mapping:
 * [c-mapping-value] <!-- : -->
 
 
-["**`,`**"] (**`#x2C`**, comma) ends a [flow collection] entry.
+["**`,`**"] (**`x2C`**, comma) ends a [flow collection] entry.
 
 ```
 [#] c-collect-entry ::= ','
 ```
 
 
-["**`[`**"] (**`#x5B`**, left bracket) starts a [flow sequence].
+["**`[`**"] (**`x5B`**, left bracket) starts a [flow sequence].
 
 ```
 [#] c-sequence-start ::= '['
 ```
 
 
-["**`]`**"] (**`#x5D`**, right bracket) ends a [flow sequence].
+["**`]`**"] (**`x5D`**, right bracket) ends a [flow sequence].
 
 ```
 [#] c-sequence-end ::= ']'
 ```
 
 
-["**`{`**"] (**`#x7B`**, left brace) starts a [flow mapping].
+["**`{`**"] (**`x7B`**, left brace) starts a [flow mapping].
 
 ```
 [#] c-mapping-start ::= '{'
 ```
 
 
-["**`}`**"] (**`#x7D`**, right brace) ends a [flow mapping].
+["**`}`**"] (**`x7D`**, right brace) ends a [flow mapping].
 
 ```
 [#] c-mapping-end ::= '}'
@@ -1618,7 +1618,7 @@ mapping: { sky: blue, sea: green }
 * [c-collect-entry] <!-- , -->
 
 
-["**`#`**"] (**`#x23`**, octothorpe, hash, sharp, pound, number sign) denotes a
+["**`#`**"] (**`x23`**, octothorpe, hash, sharp, pound, number sign) denotes a
 [comment].
 
 ```
@@ -1642,13 +1642,13 @@ mapping: { sky: blue, sea: green }
 * [c-comment] <!-- # -->
 
 
-["**`&`**"] (**`#x26`**, ampersand) denotes a [node's anchor property].
+["**`&`**"] (**`x26`**, ampersand) denotes a [node's anchor property].
 
 ```
 [#] c-anchor ::= '&'
 ```
 
-["**`*`**"] (**`#x2A`**, asterisk) denotes an [alias node].
+["**`*`**"] (**`x2A`**, asterisk) denotes an [alias node].
 
 
 ```
@@ -1656,7 +1656,7 @@ mapping: { sky: blue, sea: green }
 ```
 
 
-The ["**`!`**"] (**`#x21`**, exclamation) is heavily overloaded for specifying
+The ["**`!`**"] (**`x21`**, exclamation) is heavily overloaded for specifying
 [node tags].
 It is used to denote [tag handles] used in [tag directives] and [tag
 properties]; to denote [local tags]; and as the [non-specific tag] for
@@ -1692,7 +1692,7 @@ alias: *anchor
 ```
 
 
-["**`>`**"] (**`#x3E`**, greater than) denotes a [folded block scalar].
+["**`>`**"] (**`x3E`**, greater than) denotes a [folded block scalar].
 
 ```
 [#] c-folded ::= '>'
@@ -1719,7 +1719,7 @@ folded: >
 * [c-literal] <!-- | -->
 * [c-folded] <!-- > -->
 
-["**`'`**"] (**`#x27`**, apostrophe, single quote) surrounds a [single-quoted
+["**`'`**"] (**`x27`**, apostrophe, single quote) surrounds a [single-quoted
 flow scalar].
 
 
@@ -1728,7 +1728,7 @@ flow scalar].
 ```
 
 
-["**`"`**"] (**`#x22`**, double quote) surrounds a [double-quoted flow scalar].
+["**`"`**"] (**`x22`**, double quote) surrounds a [double-quoted flow scalar].
 
 ```
 [#] c-double-quote ::= '"'
@@ -1752,7 +1752,7 @@ double: "text"
 * [c-double-quote] <!-- 2:9 2:14 -->
 
 
-["**`%`**"] (**`#x25`**, percent) denotes a [directive] line.
+["**`%`**"] (**`x25`**, percent) denotes a [directive] line.
 
 ```
 [#] c-directive ::= '%'
@@ -1774,7 +1774,7 @@ double: "text"
 * [c-directive] <!-- % -->
 
 
-The _"**`@`**"_ (**`#x40`**, at) and _"**<code>&grave;</code>**"_ (**`#x60`**,
+The _"**`@`**"_ (**`x40`**, at) and _"**<code>&grave;</code>**"_ (**`x60`**,
 grave accent) are _reserved_ for future use.
 
 ```
@@ -1827,13 +1827,13 @@ YAML recognizes the following ASCII _line break_ characters.
 
 ```
 [#] b-line-feed ::=
-  #x0A    /* LF */
+  x0A    /* LF */
 ```
 
 
 ```
 [#] b-carriage-return ::=
-  #x0D    /* CR */
+  x0D    /* CR */
 ```
 
 
@@ -1843,10 +1843,10 @@ YAML recognizes the following ASCII _line break_ characters.
 ```
 
 
-All other characters, including the form feed (**`#x0C`**), are considered to
-be non-break characters.
-Note that these include the _non-ASCII line breaks_: next line (**`#x85`**),
-line separator (**`#x2028`**) and paragraph separator (**`#x2029`**).
+All other characters, including the form feed (**`x0C`**), are considered to be
+non-break characters.
+Note that these include the _non-ASCII line breaks_: next line (**`x85`**),
+line separator (**`x2028`**) and paragraph separator (**`x2029`**).
 
 [YAML version 1.1] did support the above non-ASCII line break characters;
 however, JSON does not.
@@ -1922,12 +1922,12 @@ YAML recognizes two _white space_ characters: _space_ and _tab_.
 
 ```
 [#] s-space ::=
-  #x20 /* SP */
+  x20 /* SP */
 ```
 
 ```
 [#] s-tab ::=
-  #x09  /* TAB */
+  x09  /* TAB */
 ```
 
 ```
@@ -1980,7 +1980,7 @@ A decimal digit for numbers:
 
 ```
 [#] ns-dec-digit ::=
-  [#x30-#x39] /* 0-9 */
+  [x30-x39] /* 0-9 */
 ```
 
 
@@ -1989,7 +1989,7 @@ A hexadecimal digit for [escape sequences]:
 ```
 [#] ns-hex-digit ::=
     ns-dec-digit
-  | [#x41-#x46] /* A-F */ | [#x61-#x66] /* a-f */
+  | [x41-x46] /* A-F */ | [x61-x66] /* a-f */
 ```
 
 
@@ -1997,7 +1997,7 @@ ASCII letter (alphabetic) characters:
 
 ```
 [#] ns-ascii-letter ::=
-  [#x41-#x5A] /* A-Z */ | [#x61-#x7A] /* a-z */
+  [x41-x5A] /* A-Z */ | [x61-x7A] /* a-z */
 ```
 
 
@@ -2057,124 +2057,124 @@ and non-[printable] characters are not available.
 
 YAML escape sequences are a superset of C's escape sequences:
 
-Escaped ASCII null (**`#x00`**) character.
+Escaped ASCII null (**`x00`**) character.
 
 ```
 [#] ns-esc-null ::= '0'
 ```
 
 
-Escaped ASCII bell (**`#x07`**) character.
+Escaped ASCII bell (**`x07`**) character.
 
 ```
 [#] ns-esc-bell ::= 'a'
 ```
 
 
-Escaped ASCII backspace (**`#x08`**) character.
+Escaped ASCII backspace (**`x08`**) character.
 
 ```
 [#] ns-esc-backspace ::= 'b'
 ```
 
 
-Escaped ASCII horizontal tab (**`#x09`**) character.
+Escaped ASCII horizontal tab (**`x09`**) character.
 This is useful at the start or the end of a line to force a leading or trailing
 tab to become part of the [content].
 
 ```
 [#] ns-esc-horizontal-tab ::=
-  't' | #x09
+  't' | x09
 ```
 
 
-Escaped ASCII line feed (**`#x0A`**) character.
+Escaped ASCII line feed (**`x0A`**) character.
 
 ```
 [#] ns-esc-line-feed ::= 'n'
 ```
 
 
-Escaped ASCII vertical tab (**`#x0B`**) character.
+Escaped ASCII vertical tab (**`x0B`**) character.
 
 ```
 [#] ns-esc-vertical-tab ::= 'v'
 ```
 
 
-Escaped ASCII form feed (**`#x0C`**) character.
+Escaped ASCII form feed (**`x0C`**) character.
 
 ```
 [#] ns-esc-form-feed ::= 'f'
 ```
 
 
-Escaped ASCII carriage return (**`#x0D`**) character.
+Escaped ASCII carriage return (**`x0D`**) character.
 
 ```
 [#] ns-esc-carriage-return ::= 'r'
 ```
 
 
-Escaped ASCII escape (**`#x1B`**) character.
+Escaped ASCII escape (**`x1B`**) character.
 
 ```
 [#] ns-esc-escape ::= 'e'
 ```
 
 
-Escaped ASCII space (**`#x20`**) character.
+Escaped ASCII space (**`x20`**) character.
 This is useful at the start or the end of a line to force a leading or trailing
 space to become part of the [content].
 
 ```
-[#] ns-esc-space ::= #x20
+[#] ns-esc-space ::= x20
 ```
 
 
-Escaped ASCII double quote (**`#x22`**).
+Escaped ASCII double quote (**`x22`**).
 
 ```
 [#] ns-esc-double-quote ::= '"'
 ```
 
 
-Escaped ASCII slash (**`#x2F`**), for [JSON compatibility].
+Escaped ASCII slash (**`x2F`**), for [JSON compatibility].
 
 ```
 [#] ns-esc-slash ::= '/'
 ```
 
 
-Escaped ASCII back slash (**`#x5C`**).
+Escaped ASCII back slash (**`x5C`**).
 
 ```
 [#] ns-esc-backslash ::= '\'
 ```
 
 
-Escaped Unicode next line (**`#x85`**) character.
+Escaped Unicode next line (**`x85`**) character.
 
 ```
 [#] ns-esc-next-line ::= 'N'
 ```
 
 
-Escaped Unicode non-breaking space (**`#xA0`**) character.
+Escaped Unicode non-breaking space (**`xA0`**) character.
 
 ```
 [#] ns-esc-non-breaking-space ::= '_'
 ```
 
 
-Escaped Unicode line separator (**`#x2028`**) character.
+Escaped Unicode line separator (**`x2028`**) character.
 
 ```
 [#] ns-esc-line-separator ::= 'L'
 ```
 
 
-Escaped Unicode paragraph separator (**`#x2029`**) character.
+Escaped Unicode paragraph separator (**`x2029`**) character.
 
 ```
 [#] ns-esc-paragraph-separator ::= 'P'
@@ -2502,7 +2502,7 @@ If a [line break] is followed by an [empty line], it is _trimmed_; the first
 
 
 Otherwise (the following line is not [empty]), the [line break] is converted to
-a single [space] (**`#x20`**).
+a single [space] (**`x20`**).
 
 ```
 [#] b-as-space ::= b-break
@@ -4595,7 +4595,7 @@ indicator for cases where detection will fail.
 
 ```
 [#] c-indentation-indicator(m) ::=
-  ns-dec-digit => m = ns-dec-digit - #x30
+  ns-dec-digit => m = ns-dec-digit - x30
   /* Empty */  => m = auto-detect()
 ```
 

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -2288,7 +2288,7 @@ convey [content] information.
 
 A [block style] construct is terminated when encountering a line which is less
 indented than the construct.
-The productions use the notation "**`s-indent(<n)`**" and "**`s-indent(≤n)`**"
+The productions use the notation "**`s-indent(<n)`**" and "**`s-indent(<=n)`**"
 to express this.
 
 ```
@@ -2297,7 +2297,7 @@ to express this.
 ```
 
 ```
-[#] s-indent(≤n) ::=
+[#] s-indent(<=n) ::=
   s-space{m} /* Where m ≤ n */
 ```
 
@@ -2412,10 +2412,10 @@ Line prefixes are a [presentation detail] and must not be used to convey
 
 ```
 [#] s-line-prefix(n,c) ::=
-  c = block-out ⇒ s-block-line-prefix(n)
-  c = block-in  ⇒ s-block-line-prefix(n)
-  c = flow-out  ⇒ s-flow-line-prefix(n)
-  c = flow-in   ⇒ s-flow-line-prefix(n)
+  c = block-out => s-block-line-prefix(n)
+  c = block-in  => s-block-line-prefix(n)
+  c = flow-out  => s-flow-line-prefix(n)
+  c = flow-in   => s-flow-line-prefix(n)
 ```
 
 ```
@@ -2736,12 +2736,12 @@ Note that structures following multi-line comment separation must be properly
 
 ```
 [#] s-separate(n,c) ::=
-  c = block-out ⇒ s-separate-lines(n)
-  c = block-in  ⇒ s-separate-lines(n)
-  c = flow-out  ⇒ s-separate-lines(n)
-  c = flow-in   ⇒ s-separate-lines(n)
-  c = block-key ⇒ s-separate-in-line
-  c = flow-key  ⇒ s-separate-in-line
+  c = block-out => s-separate-lines(n)
+  c = block-in  => s-separate-lines(n)
+  c = flow-out  => s-separate-lines(n)
+  c = flow-in   => s-separate-lines(n)
+  c = block-key => s-separate-in-line
+  c = flow-key  => s-separate-in-line
 ```
 
 ```
@@ -3585,10 +3585,10 @@ Double-quoted scalars are restricted to a single line when contained inside an
 
 ```
 [#] nb-double-text(n,c) ::=
-  c = flow-out  ⇒ nb-double-multi-line(n)
-  c = flow-in   ⇒ nb-double-multi-line(n)
-  c = block-key ⇒ nb-double-one-line
-  c = flow-key  ⇒ nb-double-one-line
+  c = flow-out  => nb-double-multi-line(n)
+  c = flow-in   => nb-double-multi-line(n)
+  c = block-key => nb-double-one-line
+  c = flow-key  => nb-double-one-line
 ```
 
 ```
@@ -3746,10 +3746,10 @@ Single-quoted scalars are restricted to a single line when contained inside a
 
 ```
 [#] nb-single-text(n,c) ::=
-  c = flow-out  ⇒ nb-single-multi-line(n)
-  c = flow-in   ⇒ nb-single-multi-line(n)
-  c = block-key ⇒ nb-single-one-line
-  c = flow-key  ⇒ nb-single-one-line
+  c = flow-out  => nb-single-multi-line(n)
+  c = flow-in   => nb-single-multi-line(n)
+  c = block-key => nb-single-one-line
+  c = flow-key  => nb-single-one-line
 ```
 
 ```
@@ -3854,10 +3854,10 @@ These characters would cause ambiguity with [flow collection] structures.
 
 ```
 [#] ns-plain-safe(c) ::=
-  c = flow-out  ⇒ ns-plain-safe-out
-  c = flow-in   ⇒ ns-plain-safe-in
-  c = block-key ⇒ ns-plain-safe-out
-  c = flow-key  ⇒ ns-plain-safe-in
+  c = flow-out  => ns-plain-safe-out
+  c = flow-in   => ns-plain-safe-in
+  c = block-key => ns-plain-safe-out
+  c = flow-key  => ns-plain-safe-in
 ```
 
 ```
@@ -3919,10 +3919,10 @@ Plain scalars are further restricted to a single line when contained inside an
 
 ```
 [#] ns-plain(n,c) ::=
-  c = flow-out  ⇒ ns-plain-multi-line(n,c)
-  c = flow-in   ⇒ ns-plain-multi-line(n,c)
-  c = block-key ⇒ ns-plain-one-line(c)
-  c = flow-key  ⇒ ns-plain-one-line(c)
+  c = flow-out  => ns-plain-multi-line(n,c)
+  c = flow-in   => ns-plain-multi-line(n,c)
+  c = block-key => ns-plain-one-line(c)
+  c = flow-key  => ns-plain-one-line(c)
 ```
 
 ```
@@ -4003,10 +4003,10 @@ This does not cause ambiguity because flow collection entries can never be
 
 ```
 [#] in-flow(c) ::=
-  c = flow-out  ⇒ flow-in
-  c = flow-in   ⇒ flow-in
-  c = block-key ⇒ flow-key
-  c = flow-key  ⇒ flow-key
+  c = flow-out  => flow-in
+  c = flow-in   => flow-in
+  c = block-key => flow-key
+  c = flow-key  => flow-key
 ```
 
 
@@ -4595,8 +4595,8 @@ indicator for cases where detection will fail.
 
 ```
 [#] c-indentation-indicator(m) ::=
-  ns-dec-digit ⇒ m = ns-dec-digit - #x30
-  /* Empty */  ⇒ m = auto-detect()
+  ns-dec-digit => m = ns-dec-digit - #x30
+  /* Empty */  => m = auto-detect()
 ```
 
 
@@ -4693,9 +4693,9 @@ convey [content] information.
 
 ```
 [#] c-chomping-indicator(t) ::=
-  '-'         ⇒ t = strip
-  '+'         ⇒ t = keep
-  /* Empty */ ⇒ t = clip
+  '-'         => t = strip
+  '+'         => t = keep
+  /* Empty */ => t = clip
 ```
 
 
@@ -4704,9 +4704,9 @@ by the chomping indicator specified in the [block scalar header].
 
 ```
 [#] b-chomped-last(t) ::=
-  t = strip ⇒ b-non-content | /* End of file */
-  t = clip  ⇒ b-as-line-feed | /* End of file */
-  t = keep  ⇒ b-as-line-feed | /* End of file */
+  t = strip => b-non-content | /* End of file */
+  t = clip  => b-as-line-feed | /* End of file */
+  t = keep  => b-as-line-feed | /* End of file */
 ```
 
 
@@ -4738,14 +4738,14 @@ header].
 
 ```
 [#] l-chomped-empty(n,t) ::=
-  t = strip ⇒ l-strip-empty(n)
-  t = clip  ⇒ l-strip-empty(n)
-  t = keep  ⇒ l-keep-empty(n)
+  t = strip => l-strip-empty(n)
+  t = clip  => l-strip-empty(n)
+  t = keep  => l-keep-empty(n)
 ```
 
 ```
 [#] l-strip-empty(n) ::=
-  ( s-indent(≤n) b-non-content )*
+  ( s-indent(<=n) b-non-content )*
   l-trail-comments(n)?
 ```
 
@@ -5506,8 +5506,8 @@ versus [**`block-in`** context]).
 
 ```
 [#] seq-spaces(n,c) ::=
-  c = block-out ⇒ n-1
-  c = block-in  ⇒ n
+  c = block-out => n-1
+  c = block-in  => n
 ```
 
 

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -1518,21 +1518,21 @@ _Indicators_ are characters that have special semantics.
 ["**`-`**"] (**`#x2D`**, hyphen) denotes a [block sequence] entry.
 
 ```
-[#] c-sequence-entry ::= "-"
+[#] c-sequence-entry ::= '-'
 ```
 
 
 ["**`?`**"] (**`#x3F`**, question mark) denotes a [mapping key].
 
 ```
-[#] c-mapping-key ::= "?"
+[#] c-mapping-key ::= '?'
 ```
 
 
 ["**`:`**"] (**`#x3A`**, colon) denotes a [mapping value].
 
 ```
-[#] c-mapping-value ::= ":"
+[#] c-mapping-value ::= ':'
 ```
 
 
@@ -1566,35 +1566,35 @@ mapping:
 ["**`,`**"] (**`#x2C`**, comma) ends a [flow collection] entry.
 
 ```
-[#] c-collect-entry ::= ","
+[#] c-collect-entry ::= ','
 ```
 
 
 ["**`[`**"] (**`#x5B`**, left bracket) starts a [flow sequence].
 
 ```
-[#] c-sequence-start ::= "["
+[#] c-sequence-start ::= '['
 ```
 
 
 ["**`]`**"] (**`#x5D`**, right bracket) ends a [flow sequence].
 
 ```
-[#] c-sequence-end ::= "]"
+[#] c-sequence-end ::= ']'
 ```
 
 
 ["**`{`**"] (**`#x7B`**, left brace) starts a [flow mapping].
 
 ```
-[#] c-mapping-start ::= "{"
+[#] c-mapping-start ::= '{'
 ```
 
 
 ["**`}`**"] (**`#x7D`**, right brace) ends a [flow mapping].
 
 ```
-[#] c-mapping-end ::= "}"
+[#] c-mapping-end ::= '}'
 ```
 
 
@@ -1621,7 +1621,7 @@ mapping: { sky: blue, sea: green }
 [comment].
 
 ```
-[#] c-comment ::= "#"
+[#] c-comment ::= '#'
 ```
 
 
@@ -1644,14 +1644,14 @@ mapping: { sky: blue, sea: green }
 ["**`&`**"] (**`#x26`**, ampersand) denotes a [node's anchor property].
 
 ```
-[#] c-anchor ::= "&"
+[#] c-anchor ::= '&'
 ```
 
 ["**`*`**"] (**`#x2A`**, asterisk) denotes an [alias node].
 
 
 ```
-[#] c-alias ::= "*"
+[#] c-alias ::= '*'
 ```
 
 
@@ -1662,7 +1662,7 @@ properties]; to denote [local tags]; and as the [non-specific tag] for
 non-[plain scalars].
 
 ```
-[#] c-tag ::= "!"
+[#] c-tag ::= '!'
 ```
 
 
@@ -1687,14 +1687,14 @@ alias: *anchor
 ["**`|`**"] (**`7C`**, vertical bar) denotes a [literal block scalar].
 
 ```
-[#] c-literal ::= "|"
+[#] c-literal ::= '|'
 ```
 
 
 ["**`>`**"] (**`#x3E`**, greater than) denotes a [folded block scalar].
 
 ```
-[#] c-folded ::= ">"
+[#] c-folded ::= '>'
 ```
 
 
@@ -1730,7 +1730,7 @@ flow scalar].
 ["**`"`**"] (**`#x22`**, double quote) surrounds a [double-quoted flow scalar].
 
 ```
-[#] c-double-quote ::= """
+[#] c-double-quote ::= '"'
 ```
 
 
@@ -1754,7 +1754,7 @@ double: "text"
 ["**`%`**"] (**`#x25`**, percent) denotes a [directive] line.
 
 ```
-[#] c-directive ::= "%"
+[#] c-directive ::= '%'
 ```
 
 
@@ -1778,7 +1778,7 @@ grave accent) are _reserved_ for future use.
 
 ```
 [#] c-reserved ::=
-  "@" | "`"
+  '@' | '`'
 ```
 
 
@@ -1802,9 +1802,9 @@ Any indicator character:
 
 ```
 [#] c-indicator ::=
-    "-" | "?" | ":" | "," | "[" | "]" | "{" | "}"
-  | "#" | "&" | "*" | "!" | "|" | ">" | "'" | """
-  | "%" | "@" | "`"
+    '-' | '?' | ':' | ',' | '[' | ']' | '{' | '}'
+  | '#' | '&' | '*' | '!' | '|' | '>' | "'" | '"'
+  | '%' | '@' | '`'
 ```
 
 
@@ -1816,7 +1816,7 @@ This is handled on a case-by-case basis by the relevant productions.
 
 ```
 [#] c-flow-indicator ::=
-  "," | "[" | "]" | "{" | "}"
+  ',' | '[' | ']' | '{' | '}'
 ```
 
 
@@ -2004,7 +2004,7 @@ Word (alphanumeric) characters for identifiers:
 
 ```
 [#] ns-word-char ::=
-  ns-dec-digit | ns-ascii-letter | "-"
+  ns-dec-digit | ns-ascii-letter | '-'
 ```
 
 URI characters for [tags], as defined in the URI specification[^uri].
@@ -2018,9 +2018,9 @@ YAML [stream], without any processing.
 
 ```
 [#] ns-uri-char ::=
-    "%" ns-hex-digit ns-hex-digit | ns-word-char | "#"
-  | ";" | "/" | "?" | ":" | "@" | "&" | "=" | "+" | "$" | ","
-  | "_" | "." | "!" | "~" | "*" | "'" | "(" | ")" | "[" | "]"
+    '%' ns-hex-digit ns-hex-digit | ns-word-char | '#'
+  | ';' | '/' | '?' | ':' | '@' | '&' | '=' | '+' | '$' | ','
+  | '_' | '.' | '!' | '~' | '*' | "'" | '(' | ')' | '[' | ']'
 ```
 
 
@@ -2032,7 +2032,7 @@ These characters would cause ambiguity with [flow collection] structures.
 
 ```
 [#] ns-tag-char ::=
-  ns-uri-char - "!" - c-flow-indicator
+  ns-uri-char - '!' - c-flow-indicator
 ```
 
 
@@ -2050,7 +2050,7 @@ In all other [scalar styles], the "**`\`**" character has no special meaning
 and non-[printable] characters are not available.
 
 ```
-[#] c-escape ::= "\"
+[#] c-escape ::= '\'
 ```
 
 
@@ -2059,21 +2059,21 @@ YAML escape sequences are a superset of C's escape sequences:
 Escaped ASCII null (**`#x00`**) character.
 
 ```
-[#] ns-esc-null ::= "0"
+[#] ns-esc-null ::= '0'
 ```
 
 
 Escaped ASCII bell (**`#x07`**) character.
 
 ```
-[#] ns-esc-bell ::= "a"
+[#] ns-esc-bell ::= 'a'
 ```
 
 
 Escaped ASCII backspace (**`#x08`**) character.
 
 ```
-[#] ns-esc-backspace ::= "b"
+[#] ns-esc-backspace ::= 'b'
 ```
 
 
@@ -2083,42 +2083,42 @@ tab to become part of the [content].
 
 ```
 [#] ns-esc-horizontal-tab ::=
-  "t" | #x09
+  't' | #x09
 ```
 
 
 Escaped ASCII line feed (**`#x0A`**) character.
 
 ```
-[#] ns-esc-line-feed ::= "n"
+[#] ns-esc-line-feed ::= 'n'
 ```
 
 
 Escaped ASCII vertical tab (**`#x0B`**) character.
 
 ```
-[#] ns-esc-vertical-tab ::= "v"
+[#] ns-esc-vertical-tab ::= 'v'
 ```
 
 
 Escaped ASCII form feed (**`#x0C`**) character.
 
 ```
-[#] ns-esc-form-feed ::= "f"
+[#] ns-esc-form-feed ::= 'f'
 ```
 
 
 Escaped ASCII carriage return (**`#x0D`**) character.
 
 ```
-[#] ns-esc-carriage-return ::= "r"
+[#] ns-esc-carriage-return ::= 'r'
 ```
 
 
 Escaped ASCII escape (**`#x1B`**) character.
 
 ```
-[#] ns-esc-escape ::= "e"
+[#] ns-esc-escape ::= 'e'
 ```
 
 
@@ -2134,49 +2134,49 @@ space to become part of the [content].
 Escaped ASCII double quote (**`#x22`**).
 
 ```
-[#] ns-esc-double-quote ::= """
+[#] ns-esc-double-quote ::= '"'
 ```
 
 
 Escaped ASCII slash (**`#x2F`**), for [JSON compatibility].
 
 ```
-[#] ns-esc-slash ::= "/"
+[#] ns-esc-slash ::= '/'
 ```
 
 
 Escaped ASCII back slash (**`#x5C`**).
 
 ```
-[#] ns-esc-backslash ::= "\"
+[#] ns-esc-backslash ::= '\'
 ```
 
 
 Escaped Unicode next line (**`#x85`**) character.
 
 ```
-[#] ns-esc-next-line ::= "N"
+[#] ns-esc-next-line ::= 'N'
 ```
 
 
 Escaped Unicode non-breaking space (**`#xA0`**) character.
 
 ```
-[#] ns-esc-non-breaking-space ::= "_"
+[#] ns-esc-non-breaking-space ::= '_'
 ```
 
 
 Escaped Unicode line separator (**`#x2028`**) character.
 
 ```
-[#] ns-esc-line-separator ::= "L"
+[#] ns-esc-line-separator ::= 'L'
 ```
 
 
 Escaped Unicode paragraph separator (**`#x2029`**) character.
 
 ```
-[#] ns-esc-paragraph-separator ::= "P"
+[#] ns-esc-paragraph-separator ::= 'P'
 ```
 
 
@@ -2184,7 +2184,7 @@ Escaped 8-bit Unicode character.
 
 ```
 [#] ns-esc-8-bit ::=
-  "x"
+  'x'
   ( ns-hex-digit × 2 )
 ```
 
@@ -2193,7 +2193,7 @@ Escaped 16-bit Unicode character.
 
 ```
 [#] ns-esc-16-bit ::=
-  "u"
+  'u'
   ( ns-hex-digit × 4 )
 ```
 
@@ -2202,7 +2202,7 @@ Escaped 32-bit Unicode character.
 
 ```
 [#] ns-esc-32-bit ::=
-  "U"
+  'U'
   ( ns-hex-digit × 8 )
 ```
 
@@ -2211,7 +2211,7 @@ Any escaped character:
 
 ```
 [#] c-ns-esc-char ::=
-  "\"
+  '\'
   ( ns-esc-null | ns-esc-bell | ns-esc-backspace
   | ns-esc-horizontal-tab | ns-esc-line-feed
   | ns-esc-vertical-tab | ns-esc-form-feed
@@ -2632,7 +2632,7 @@ However, as this confuses many tools, YAML [processors] should terminate the
 
 ```
 [#] c-nb-comment-text ::=
-  "#" nb-char*
+  '#' nb-char*
 ```
 
 ```
@@ -2787,7 +2787,7 @@ information.
 
 ```
 [#] l-directive ::=
-  "%"
+  '%'
   ( ns-yaml-directive
   | ns-tag-directive
   | ns-reserved-directive )
@@ -2860,13 +2860,13 @@ of [non-ASCII line breaks], as described [above]).
 
 ```
 [#] ns-yaml-directive ::=
-  "Y" "A" "M" "L"
+  'Y' 'A' 'M' 'L'
   s-separate-in-line ns-yaml-version
 ```
 
 ```
 [#] ns-yaml-version ::=
-  ns-dec-digit+ "." ns-dec-digit+
+  ns-dec-digit+ '.' ns-dec-digit+
 ```
 
 
@@ -2918,7 +2918,7 @@ This allows for compact and readable [tag] notation.
 
 ```
 [#] ns-tag-directive ::=
-  "T" "A" "G"
+  'T' 'A' 'G'
   s-separate-in-line c-tag-handle
   s-separate-in-line ns-tag-prefix
 ```
@@ -2992,7 +2992,7 @@ This provides smooth migration from using [local tags] to using [global tags]
 by the simple addition of a single "**`TAG`**" directive.
 
 ```
-[#] c-primary-tag-handle ::= "!"
+[#] c-primary-tag-handle ::= '!'
 ```
 
 
@@ -3030,7 +3030,7 @@ By default, the prefix associated with this handle is
 
 ```
 [#] c-secondary-tag-handle ::=
-  "!" "!"
+  '!' '!'
 ```
 
 
@@ -3063,7 +3063,7 @@ In particular, the YAML [processor] need not preserve the handle name once
 
 ```
 [#] c-named-tag-handle ::=
-  "!" ns-word-char+ "!"
+  '!' ns-word-char+ '!'
 ```
 
 
@@ -3104,7 +3104,7 @@ semantics to the same [local tag].
 
 ```
 [#] c-ns-local-tag-prefix ::=
-  "!" ns-uri-char*
+  '!' ns-uri-char*
 ```
 
 
@@ -3222,7 +3222,7 @@ valid URI (a [global tag]).
 
 ```
 [#] c-verbatim-tag ::=
-  "!" "<" ns-uri-char+ ">"
+  '!' '<' ns-uri-char+ '>'
 ```
 
 
@@ -3256,7 +3256,7 @@ ERROR:
   so ! is invalid.
 - The $:? tag is neither a global
   URI tag nor a local tag starting
-  with "!".
+  with '!'.
 ```
 <!-- 3:6 -->
 <!-- 4:7,3 -->
@@ -3352,7 +3352,7 @@ interpreted as "**`tag:yaml.org,2002:seq`**", "**`tag:yaml.org,2002:map`**" or
 This is intentional.
 
 ```
-[#] c-non-specific-tag ::= "!"
+[#] c-non-specific-tag ::= '!'
 ```
 
 
@@ -3386,7 +3386,7 @@ it is valid for all [nodes] to be anchored.
 
 ```
 [#] c-ns-anchor-property ::=
-  "&" ns-anchor-name
+  '&' ns-anchor-name
 ```
 
 
@@ -3454,7 +3454,7 @@ these were already specified at the first occurrence of the [node].
 
 ```
 [#] c-ns-alias-node ::=
-  "*" ns-anchor-name
+  '*' ns-anchor-name
 ```
 
 
@@ -3565,7 +3565,7 @@ characters.
 
 ```
 [#] nb-double-char ::=
-  c-ns-esc-char | ( nb-json - "\" - """ )
+  c-ns-esc-char | ( nb-json - '\' - '"' )
 ```
 
 ```
@@ -3579,7 +3579,7 @@ Double-quoted scalars are restricted to a single line when contained inside an
 
 ```
 [#] c-double-quoted(n,c) ::=
-  """ nb-double-text(n,c) """
+  '"' nb-double-text(n,c) '"'
 ```
 
 ```
@@ -3623,7 +3623,7 @@ double-quoted lines to be broken at arbitrary positions.
 
 ```
 [#] s-double-escaped(n) ::=
-  s-white* "\" b-non-content
+  s-white* '\' b-non-content
   l-empty(n,flow-in)* s-flow-line-prefix(n)
 ```
 
@@ -3837,7 +3837,7 @@ causes no ambiguity.
 ```
 [#] ns-plain-first(c) ::=
     ( ns-char - c-indicator )
-  | ( ( "?" | ":" | "-" )
+  | ( ( '?' | ':' | '-' )
       /* Followed by an ns-plain-safe(c)) */ )
 ```
 
@@ -3870,9 +3870,9 @@ These characters would cause ambiguity with [flow collection] structures.
 
 ```
 [#] ns-plain-char(c) ::=
-    ( ns-plain-safe(c) - ":" - "#" )
-  | ( /* An ns-char preceding */ "#" )
-  | ( ":" /* Followed by an ns-plain-safe(c) */ )
+    ( ns-plain-safe(c) - ':' - '#' )
+  | ( /* An ns-char preceding */ '#' )
+  | ( ':' /* Followed by an ns-plain-safe(c) */ )
 ```
 
 
@@ -4016,8 +4016,8 @@ characters.
 
 ```
 [#] c-flow-sequence(n,c) ::=
-  "[" s-separate(n,c)?
-  ns-s-flow-seq-entries(n,in-flow(c))? "]"
+  '[' s-separate(n,c)?
+  ns-s-flow-seq-entries(n,in-flow(c))? ']'
 ```
 
 
@@ -4026,7 +4026,7 @@ Sequence entries are separated by a ["**`,`**"] character.
 ```
 [#] ns-s-flow-seq-entries(n,c) ::=
   ns-flow-seq-entry(n,c) s-separate(n,c)?
-  ( "," s-separate(n,c)?
+  ( ',' s-separate(n,c)?
     ns-s-flow-seq-entries(n,c)? )?
 ```
 
@@ -4093,8 +4093,8 @@ characters.
 
 ```
 [#] c-flow-mapping(n,c) ::=
-  "{" s-separate(n,c)?
-  ns-s-flow-map-entries(n,in-flow(c))? "}"
+  '{' s-separate(n,c)?
+  ns-s-flow-map-entries(n,in-flow(c))? '}'
 ```
 
 
@@ -4103,7 +4103,7 @@ Mapping entries are separated by a ["**`,`**"] character.
 ```
 [#] ns-s-flow-map-entries(n,c) ::=
   ns-flow-map-entry(n,c) s-separate(n,c)?
-  ( "," s-separate(n,c)?
+  ( ',' s-separate(n,c)?
     ns-s-flow-map-entries(n,c)? )?
 ```
 
@@ -4132,7 +4132,7 @@ entry may be [completely empty].
 
 ```
 [#] ns-flow-map-entry(n,c) ::=
-    ( "?" s-separate(n,c)
+    ( '?' s-separate(n,c)
       ns-flow-map-explicit-entry(n,c) )
   | ns-flow-map-implicit-entry(n,c)
 ```
@@ -4201,7 +4201,7 @@ indicated by the "**`:`**".
 
 ```
 [#] c-ns-flow-map-separate-value(n,c) ::=
-  ":" /* Not followed by an
+  ':' /* Not followed by an
          ns-plain-safe(c) */
   ( ( s-separate(n,c) ns-flow-node(n,c) )
   | e-node /* Value */ )
@@ -4250,7 +4250,7 @@ However, as this greatly reduces readability, YAML [processors] should
 
 ```
 [#] c-ns-flow-map-adjacent-value(n,c) ::=
-  ":" ( ( s-separate(n,c)?
+  ':' ( ( s-separate(n,c)?
           ns-flow-node(n,c) )
       | e-node ) /* Value */
 ```
@@ -4307,7 +4307,7 @@ and the syntax is identical to the general case.
 
 ```
 [#] ns-flow-pair(n,c) ::=
-    ( "?" s-separate(n,c)
+    ( '?' s-separate(n,c)
       ns-flow-map-explicit-entry(n,c) )
   | ns-flow-pair-entry(n,c)
 ```
@@ -4692,8 +4692,8 @@ convey [content] information.
 
 ```
 [#] c-chomping-indicator(t) ::=
-  "-"         ⇒ t = strip
-  "+"         ⇒ t = keep
+  '-'         ⇒ t = strip
+  '+'         ⇒ t = keep
   /* Empty */ ⇒ t = clip
 ```
 
@@ -4837,7 +4837,7 @@ It is the simplest, most restricted and most readable [scalar style].
 
 ```
 [#] c-l+literal(n) ::=
-  "|" c-b-block-header(m,t)
+  '|' c-b-block-header(m,t)
   l-literal-content(n+m,t)
 ```
 
@@ -4922,7 +4922,7 @@ It is similar to the [literal style]; however, folded scalars are subject to
 
 ```
 [#] c-l+folded(n) ::=
-  ">" c-b-block-header(m,t)
+  '>' c-b-block-header(m,t)
   l-folded-content(n+m,t)
 ```
 
@@ -5161,7 +5161,7 @@ followed by a non-space character (e.g. "**`-1`**").
 
 ```
 [#] c-l-block-seq-entry(n) ::=
-  "-" /* Not followed by an ns-char */
+  '-' /* Not followed by an ns-char */
   s-l+block-indented(n,block-in)
 ```
 
@@ -5283,13 +5283,13 @@ for [block sequence] entries.
 
 ```
 [#] c-l-block-map-explicit-key(n) ::=
-  "?" s-l+block-indented(n,block-out)
+  '?' s-l+block-indented(n,block-out)
 ```
 
 ```
 [#] l-block-map-explicit-value(n) ::=
   s-indent(n)
-  ":" s-l+block-indented(n,block-out)
+  ':' s-l+block-indented(n,block-out)
 ```
 
 
@@ -5350,7 +5350,7 @@ This prevents a potential ambiguity with multi-line [plain scalars].
 
 ```
 [#] c-l-block-map-implicit-value(n) ::=
-  ":" ( s-l+block-node(n,block-out)
+  ':' ( s-l+block-node(n,block-out)
       | ( e-node s-l-comments ) )
 ```
 
@@ -5603,12 +5603,12 @@ either of these markers.
 
 ```
 [#] c-directives-end ::=
-  "-" "-" "-"
+  '-' '-' '-'
 ```
 
 ```
 [#] c-document-end ::=
-  "." "." "."
+  '.' '.' '.'
 ```
 
 ```

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -1397,9 +1397,9 @@ extensive character property tables.
 
 ```
 [#] c-printable ::=
-    x09 | x0A | x0D | [x20-x7E]       /* 8 bit */
-  | x85 | [xA0-xD7FF] | [xE000-xFFFD] /* 16 bit */
-  | [x010000-x10FFFF]                 /* 32 bit */
+  ( x09 | x0A | x0D | [x20-x7E]         /* 8 bit */
+  | x85 | [xA0-xD7FF] | [xE000-xFFFD]   /* 16 bit */
+  | [x010000-x10FFFF] )                 /* 32 bit */
 ```
 
 
@@ -1413,7 +1413,8 @@ YAML [quoted scalars] can.
 
 ```
 [#] nb-json ::=
-  x09 | [x20-x10FFFF]
+  ( x09
+  | [x20-x10FFFF] )
 ```
 
 > Note: The production name `nb-json` means "non-break JSON compatible" here.
@@ -1779,7 +1780,8 @@ grave accent) are _reserved_ for future use.
 
 ```
 [#] c-reserved ::=
-  '@' | '`'
+  ( '@'
+  | '`' )
 ```
 
 
@@ -1803,9 +1805,25 @@ Any indicator character:
 
 ```
 [#] c-indicator ::=
-    '-' | '?' | ':' | ',' | '[' | ']' | '{' | '}'
-  | '#' | '&' | '*' | '!' | '|' | '>' | "'" | '"'
-  | '%' | '@' | '`'
+  ( '-'
+  | '?'
+  | ':'
+  | ','
+  | '['
+  | ']'
+  | '{'
+  | '}'
+  | '#'
+  | '&'
+  | '*'
+  | '!'
+  | '|'
+  | '>'
+  | "'"
+  | '"'
+  | '%'
+  | '@'
+  | '`' )
 ```
 
 
@@ -1817,7 +1835,11 @@ This is handled on a case-by-case basis by the relevant productions.
 
 ```
 [#] c-flow-indicator ::=
-  ',' | '[' | ']' | '{' | '}'
+  ( ','
+  | '['
+  | ']'
+  | '{'
+  | '}' )
 ```
 
 
@@ -1826,20 +1848,19 @@ This is handled on a case-by-case basis by the relevant productions.
 YAML recognizes the following ASCII _line break_ characters.
 
 ```
-[#] b-line-feed ::=
-  x0A    /* LF */
+[#] b-line-feed ::= x0A
 ```
 
 
 ```
-[#] b-carriage-return ::=
-  x0D    /* CR */
+[#] b-carriage-return ::= x0D
 ```
 
 
 ```
 [#] b-char ::=
-  b-line-feed | b-carriage-return
+  ( b-line-feed
+  | b-carriage-return )
 ```
 
 
@@ -1859,7 +1880,10 @@ treat these line breaks as non-break characters, with an appropriate warning.
 
 ```
 [#] nb-char ::=
-  c-printable - b-char - c-byte-order-mark
+  ( c-printable
+  - b-char
+  - c-byte-order-mark
+  )
 ```
 
 
@@ -1868,9 +1892,10 @@ widely used formats.
 
 ```
 [#] b-break ::=
-    ( b-carriage-return b-line-feed ) /* DOS, Windows */
-  | b-carriage-return                 /* MacOS up to 9.x */
-  | b-line-feed                       /* UNIX, MacOS X */
+  ( ( b-carriage-return
+      b-line-feed )
+  | b-carriage-return
+  | b-line-feed )
 ```
 
 
@@ -1881,7 +1906,8 @@ The original line break format is a [presentation detail] and must not be used
 to convey [content] information.
 
 ```
-[#] b-as-line-feed ::= b-break
+[#] b-as-line-feed ::=
+  b-break
 ```
 
 
@@ -1889,7 +1915,8 @@ Outside [scalar content], YAML allows any line break to be used to terminate
 lines.
 
 ```
-[#] b-non-content ::= b-break
+[#] b-non-content ::=
+  b-break
 ```
 
 
@@ -1921,18 +1948,17 @@ for clarity.
 YAML recognizes two _white space_ characters: _space_ and _tab_.
 
 ```
-[#] s-space ::=
-  x20 /* SP */
+[#] s-space ::= x20
 ```
 
 ```
-[#] s-tab ::=
-  x09  /* TAB */
+[#] s-tab ::= x09
 ```
 
 ```
 [#] s-white ::=
-  s-space | s-tab
+  ( s-space
+  | s-tab )
 ```
 
 
@@ -1941,7 +1967,9 @@ non-space characters.
 
 ```
 [#] ns-char ::=
-  nb-char - s-white
+  ( nb-char
+  - s-white
+  )
 ```
 
 
@@ -1980,7 +2008,7 @@ A decimal digit for numbers:
 
 ```
 [#] ns-dec-digit ::=
-  [x30-x39] /* 0-9 */
+  [x30-x39]
 ```
 
 
@@ -1988,8 +2016,9 @@ A hexadecimal digit for [escape sequences]:
 
 ```
 [#] ns-hex-digit ::=
-    ns-dec-digit
-  | [x41-x46] /* A-F */ | [x61-x66] /* a-f */
+  ( ns-dec-digit
+  | [x41-x46]
+  | [x61-x66] )
 ```
 
 
@@ -1997,7 +2026,8 @@ ASCII letter (alphabetic) characters:
 
 ```
 [#] ns-ascii-letter ::=
-  [x41-x5A] /* A-Z */ | [x61-x7A] /* a-z */
+  ( [x41-x5A]
+  | [x61-x7A] )
 ```
 
 
@@ -2005,7 +2035,9 @@ Word (alphanumeric) characters for identifiers:
 
 ```
 [#] ns-word-char ::=
-  ns-dec-digit | ns-ascii-letter | '-'
+  ( ns-dec-digit
+  | ns-ascii-letter
+  | '-' )
 ```
 
 URI characters for [tags], as defined in the URI specification[^uri].
@@ -2019,9 +2051,29 @@ YAML [stream], without any processing.
 
 ```
 [#] ns-uri-char ::=
-    '%' ns-hex-digit ns-hex-digit | ns-word-char | '#'
-  | ';' | '/' | '?' | ':' | '@' | '&' | '=' | '+' | '$' | ','
-  | '_' | '.' | '!' | '~' | '*' | "'" | '(' | ')' | '[' | ']'
+  ( '%' ns-hex-digit ns-hex-digit  <!-- fixme -->
+  | ns-word-char
+  | '#'
+  | ';'
+  | '/'
+  | '?'
+  | ':'
+  | '@'
+  | '&'
+  | '='
+  | '+'
+  | '$'
+  | ','
+  | '_'
+  | '.'
+  | '!'
+  | '~'
+  | '*'
+  | "'"
+  | '('
+  | ')'
+  | '['
+  | ']' )
 ```
 
 
@@ -2033,7 +2085,10 @@ These characters would cause ambiguity with [flow collection] structures.
 
 ```
 [#] ns-tag-char ::=
-  ns-uri-char - '!' - c-flow-indicator
+  ( ns-uri-char
+  - c-tag               # '!'
+  - c-flow-indicator
+  )
 ```
 
 
@@ -2084,7 +2139,8 @@ tab to become part of the [content].
 
 ```
 [#] ns-esc-horizontal-tab ::=
-  't' | x09
+  ( 't'
+  | x09 )
 ```
 
 
@@ -2213,14 +2269,26 @@ Any escaped character:
 ```
 [#] c-ns-esc-char ::=
   '\'
-  ( ns-esc-null | ns-esc-bell | ns-esc-backspace
-  | ns-esc-horizontal-tab | ns-esc-line-feed
-  | ns-esc-vertical-tab | ns-esc-form-feed
-  | ns-esc-carriage-return | ns-esc-escape | ns-esc-space
-  | ns-esc-double-quote | ns-esc-slash | ns-esc-backslash
-  | ns-esc-next-line | ns-esc-non-breaking-space
-  | ns-esc-line-separator | ns-esc-paragraph-separator
-  | ns-esc-8-bit | ns-esc-16-bit | ns-esc-32-bit )
+  ( ns-esc-null
+  | ns-esc-bell
+  | ns-esc-backspace
+  | ns-esc-horizontal-tab
+  | ns-esc-line-feed
+  | ns-esc-vertical-tab
+  | ns-esc-form-feed
+  | ns-esc-carriage-return
+  | ns-esc-escape
+  | ns-esc-space
+  | ns-esc-double-quote
+  | ns-esc-slash
+  | ns-esc-backslash
+  | ns-esc-next-line
+  | ns-esc-non-breaking-space
+  | ns-esc-line-separator
+  | ns-esc-paragraph-separator
+  | ns-esc-8-bit
+  | ns-esc-16-bit
+  | ns-esc-32-bit )
 ```
 
 
@@ -2293,12 +2361,14 @@ to express this.
 
 ```
 [#] s-indent(<n) ::=
-  s-space{m} /* Where m < n */
+  s-space{m}
+  /* Where m < n */
 ```
 
 ```
 [#] s-indent(<=n) ::=
-  s-space{m} /* Where m ≤ n */
+  s-space{m}
+  /* Where m ≤ n */
 ```
 
 
@@ -2378,7 +2448,8 @@ Separation spaces are a [presentation detail] and must not be used to convey
 
 ```
 [#] s-separate-in-line ::=
-  s-white+ | /* Start of line */
+  ( s-white+
+  | /* Start of line */ )
 ```
 
 
@@ -2419,12 +2490,14 @@ Line prefixes are a [presentation detail] and must not be used to convey
 ```
 
 ```
-[#] s-block-line-prefix(n) ::= s-indent(n)
+[#] s-block-line-prefix(n) ::=
+  s-indent(n)
 ```
 
 ```
 [#] s-flow-line-prefix(n) ::=
-  s-indent(n) s-separate-in-line?
+  s-indent(n)
+  s-separate-in-line?
 ```
 
 
@@ -2459,7 +2532,8 @@ break].
 
 ```
 [#] l-empty(n,c) ::=
-  ( s-line-prefix(n,c) | s-indent(<n) )
+  ( s-line-prefix(n,c)
+  | s-indent(<n) )
   b-as-line-feed
 ```
 
@@ -2497,7 +2571,8 @@ If a [line break] is followed by an [empty line], it is _trimmed_; the first
 
 ```
 [#] b-l-trimmed(n,c) ::=
-  b-non-content l-empty(n,c)+
+  b-non-content
+  l-empty(n,c)+
 ```
 
 
@@ -2505,7 +2580,8 @@ Otherwise (the following line is not [empty]), the [line break] is converted to
 a single [space] (**`x20`**).
 
 ```
-[#] b-as-space ::= b-break
+[#] b-as-space ::=
+  b-break
 ```
 
 
@@ -2513,7 +2589,8 @@ A folded non-[empty line] may end with either of the above [line breaks].
 
 ```
 [#] b-l-folded(n,c) ::=
-  b-l-trimmed(n,c) | b-as-space
+  ( b-l-trimmed(n,c)
+  | b-as-space )
 ```
 
 
@@ -2594,7 +2671,8 @@ can be freely [more-indented] without affecting the [content] information.
 
 ```
 [#] s-flow-folded(n) ::=
-  s-separate-in-line? b-l-folded(n,flow-in)
+  s-separate-in-line?
+  b-l-folded(n,flow-in)
   s-flow-line-prefix(n)
 ```
 
@@ -2633,17 +2711,20 @@ However, as this confuses many tools, YAML [processors] should terminate the
 
 ```
 [#] c-nb-comment-text ::=
-  '#' nb-char*
+  '#'
+  nb-char*
 ```
 
 ```
 [#] b-comment ::=
-  b-non-content | /* End of file */
+  ( b-non-content
+  | /* End of file */ )
 ```
 
 ```
 [#] s-b-comment ::=
-  ( s-separate-in-line c-nb-comment-text? )?
+  ( s-separate-in-line
+    c-nb-comment-text? )?
   b-comment
 ```
 
@@ -2672,7 +2753,9 @@ characters is taken to be a comment line.
 
 ```
 [#] l-comment ::=
-  s-separate-in-line c-nb-comment-text? b-comment
+  s-separate-in-line
+  c-nb-comment-text?
+  b-comment
 ```
 
 
@@ -2700,7 +2783,8 @@ The only exception is a comment ending a [block scalar header].
 
 ```
 [#] s-l-comments ::=
-  ( s-b-comment | /* Start of line */ )
+  ( s-b-comment
+  | /* Start of line */ )
   l-comment*
 ```
 
@@ -2746,8 +2830,10 @@ Note that structures following multi-line comment separation must be properly
 
 ```
 [#] s-separate-lines(n) ::=
-    ( s-l-comments s-flow-line-prefix(n) )
-  | s-separate-in-line
+  ( ( s-l-comments
+      s-flow-line-prefix(n)
+    )
+  | s-separate-in-line )
 ```
 
 
@@ -2805,15 +2891,19 @@ warning.
 ```
 [#] ns-reserved-directive ::=
   ns-directive-name
-  ( s-separate-in-line ns-directive-parameter )*
+  ( s-separate-in-line
+    ns-directive-parameter
+  )*
 ```
 
 ```
-[#] ns-directive-name ::= ns-char+
+[#] ns-directive-name ::=
+  ns-char+
 ```
 
 ```
-[#] ns-directive-parameter ::= ns-char+
+[#] ns-directive-parameter ::=
+  ns-char+
 ```
 
 
@@ -2861,13 +2951,16 @@ of [non-ASCII line breaks], as described [above]).
 
 ```
 [#] ns-yaml-directive ::=
-  'Y' 'A' 'M' 'L'
-  s-separate-in-line ns-yaml-version
+  "YAML"
+  s-separate-in-line
+  ns-yaml-version
 ```
 
 ```
 [#] ns-yaml-version ::=
-  ns-dec-digit+ '.' ns-dec-digit+
+  ns-dec-digit+
+  '.'
+  ns-dec-digit+
 ```
 
 
@@ -2919,9 +3012,11 @@ This allows for compact and readable [tag] notation.
 
 ```
 [#] ns-tag-directive ::=
-  'T' 'A' 'G'
-  s-separate-in-line c-tag-handle
-  s-separate-in-line ns-tag-prefix
+  "TAG"
+  s-separate-in-line
+  c-tag-handle
+  s-separate-in-line
+  ns-tag-prefix
 ```
 
 
@@ -2972,9 +3067,9 @@ There are three tag handle variants:
 
 ```
 [#] c-tag-handle ::=
-    c-named-tag-handle
+  ( c-named-tag-handle
   | c-secondary-tag-handle
-  | c-primary-tag-handle
+  | c-primary-tag-handle )
 ```
 
 
@@ -3030,8 +3125,7 @@ By default, the prefix associated with this handle is
 "**`TAG`**" directive associating a different prefix for this handle.
 
 ```
-[#] c-secondary-tag-handle ::=
-  '!' '!'
+[#] c-secondary-tag-handle ::= "!!"
 ```
 
 
@@ -3064,7 +3158,9 @@ In particular, the YAML [processor] need not preserve the handle name once
 
 ```
 [#] c-named-tag-handle ::=
-  '!' ns-word-char+ '!'
+  '!'
+  ns-word-char+
+  '!'
 ```
 
 
@@ -3090,7 +3186,8 @@ There are two _tag prefix_ variants:
 
 ```
 [#] ns-tag-prefix ::=
-  c-ns-local-tag-prefix | ns-global-tag-prefix
+  ( c-ns-local-tag-prefix
+  | ns-global-tag-prefix )
 ```
 
 
@@ -3105,7 +3202,8 @@ semantics to the same [local tag].
 
 ```
 [#] c-ns-local-tag-prefix ::=
-  '!' ns-uri-char*
+  '!'
+  ns-uri-char*
 ```
 
 
@@ -3142,7 +3240,8 @@ semantics to the same [global tag].
 
 ```
 [#] ns-global-tag-prefix ::=
-  ns-tag-char ns-uri-char*
+  ns-tag-char
+  ns-uri-char*
 ```
 
 
@@ -3171,10 +3270,15 @@ Either or both may be omitted.
 
 ```
 [#] c-ns-properties(n,c) ::=
-    ( c-ns-tag-property
-      ( s-separate(n,c) c-ns-anchor-property )? )
+  ( ( c-ns-tag-property
+      ( s-separate(n,c)
+        c-ns-anchor-property )?
+    )
   | ( c-ns-anchor-property
-      ( s-separate(n,c) c-ns-tag-property )? )
+      ( s-separate(n,c)
+        c-ns-tag-property )?
+    )
+  )
 ```
 
 
@@ -3205,9 +3309,9 @@ A tag is denoted by the _"**`!`**" indicator_.
 
 ```
 [#] c-ns-tag-property ::=
-    c-verbatim-tag
+  ( c-verbatim-tag
   | c-ns-shorthand-tag
-  | c-non-specific-tag
+  | c-non-specific-tag )
 ```
 
 
@@ -3223,7 +3327,9 @@ valid URI (a [global tag]).
 
 ```
 [#] c-verbatim-tag ::=
-  '!' '<' ns-uri-char+ '>'
+  "!<"
+  ns-uri-char+
+  '>'
 ```
 
 
@@ -3290,7 +3396,8 @@ This behavior is consistent with the URI character escaping rules
 
 ```
 [#] c-ns-shorthand-tag ::=
-  c-tag-handle ns-tag-char+
+  c-tag-handle
+  ns-tag-char+
 ```
 
 
@@ -3387,7 +3494,8 @@ it is valid for all [nodes] to be anchored.
 
 ```
 [#] c-ns-anchor-property ::=
-  '&' ns-anchor-name
+  '&'
+  ns-anchor-name
 ```
 
 
@@ -3404,11 +3512,14 @@ These characters would cause ambiguity with [flow collection] structures.
 
 ```
 [#] ns-anchor-char ::=
-  ns-char - c-flow-indicator
+  ( ns-char
+  - c-flow-indicator
+  )
 ```
 
 ```
-[#] ns-anchor-name ::= ns-anchor-char+
+[#] ns-anchor-name ::=
+  ns-anchor-char+
 ```
 
 
@@ -3455,7 +3566,8 @@ these were already specified at the first occurrence of the [node].
 
 ```
 [#] c-ns-alias-node ::=
-  '*' ns-anchor-name
+  '*'
+  ns-anchor-name
 ```
 
 
@@ -3523,7 +3635,8 @@ Completely empty nodes are only valid when following some explicit indication
 for their existence.
 
 ```
-[#] e-node ::= e-scalar
+[#] e-node ::=
+  e-scalar
 ```
 
 
@@ -3566,12 +3679,19 @@ characters.
 
 ```
 [#] nb-double-char ::=
-  c-ns-esc-char | ( nb-json - '\' - '"' )
+  ( c-ns-esc-char
+  | ( nb-json
+    - '\'
+    - '"'
+    )
+  )
 ```
 
 ```
 [#] ns-double-char ::=
-  nb-double-char - s-white
+  ( nb-double-char
+  - s-white
+  )
 ```
 
 
@@ -3580,7 +3700,9 @@ Double-quoted scalars are restricted to a single line when contained inside an
 
 ```
 [#] c-double-quoted(n,c) ::=
-  '"' nb-double-text(n,c) '"'
+  '"'
+  nb-double-text(n,c)
+  '"'
 ```
 
 ```
@@ -3592,7 +3714,8 @@ Double-quoted scalars are restricted to a single line when contained inside an
 ```
 
 ```
-[#] nb-double-one-line ::= nb-double-char*
+[#] nb-double-one-line ::=
+  nb-double-char*
 ```
 
 
@@ -3624,13 +3747,17 @@ double-quoted lines to be broken at arbitrary positions.
 
 ```
 [#] s-double-escaped(n) ::=
-  s-white* '\' b-non-content
-  l-empty(n,flow-in)* s-flow-line-prefix(n)
+  s-white*
+  '\'
+  b-non-content
+  l-empty(n,flow-in)*
+  s-flow-line-prefix(n)
 ```
 
 ```
 [#] s-double-break(n) ::=
-  s-double-escaped(n) | s-flow-folded(n)
+  ( s-double-escaped(n)
+  | s-flow-folded(n) )
 ```
 
 
@@ -3661,20 +3788,25 @@ Empty lines, if any, are consumed as part of the [line folding].
 
 ```
 [#] nb-ns-double-in-line ::=
-  ( s-white* ns-double-char )*
+  ( s-white*
+    ns-double-char
+  )*
 ```
 
 ```
 [#] s-double-next-line(n) ::=
   s-double-break(n)
   ( ns-double-char nb-ns-double-in-line
-    ( s-double-next-line(n) | s-white* ) )?
+    ( s-double-next-line(n)
+    | s-white* )
+  )?
 ```
 
 ```
 [#] nb-double-multi-line(n) ::=
   nb-ns-double-in-line
-  ( s-double-next-line(n) | s-white* )
+  ( s-double-next-line(n)
+  | s-white* )
 ```
 
 
@@ -3707,18 +3839,23 @@ In addition, it is only possible to break a long single-quoted line where a
 [space] character is surrounded by non-[spaces].
 
 ```
-[#] c-quoted-quote ::=
-  "'" "'"
+[#] c-quoted-quote ::= "''"
 ```
 
 ```
 [#] nb-single-char ::=
-  c-quoted-quote | ( nb-json - "'" )
+  ( c-quoted-quote
+  | ( nb-json
+    - "'"
+    )
+  )
 ```
 
 ```
 [#] ns-single-char ::=
-  nb-single-char - s-white
+  ( nb-single-char
+  - s-white
+  )
 ```
 
 
@@ -3741,7 +3878,9 @@ Single-quoted scalars are restricted to a single line when contained inside a
 
 ```
 [#] c-single-quoted(n,c) ::=
-  "'" nb-single-text(n,c) "'"
+  "'"
+  nb-single-text(n,c)
+  "'"
 ```
 
 ```
@@ -3753,7 +3892,8 @@ Single-quoted scalars are restricted to a single line when contained inside a
 ```
 
 ```
-[#] nb-single-one-line ::= nb-single-char*
+[#] nb-single-one-line ::=
+  nb-single-char*
 ```
 
 
@@ -3783,20 +3923,26 @@ Empty lines, if any, are consumed as part of the [line folding].
 
 ```
 [#] nb-ns-single-in-line ::=
-  ( s-white* ns-single-char )*
+  ( s-white*
+    ns-single-char
+  )*
 ```
 
 ```
 [#] s-single-next-line(n) ::=
   s-flow-folded(n)
-  ( ns-single-char nb-ns-single-in-line
-    ( s-single-next-line(n) | s-white* ) )?
+  ( ns-single-char
+    nb-ns-single-in-line
+    ( s-single-next-line(n)
+    | s-white* )
+  )?
 ```
 
 ```
 [#] nb-single-multi-line(n) ::=
   nb-ns-single-in-line
-  ( s-single-next-line(n) | s-white* )
+  ( s-single-next-line(n)
+  | s-white* )
 ```
 
 
@@ -3837,9 +3983,17 @@ causes no ambiguity.
 
 ```
 [#] ns-plain-first(c) ::=
-    ( ns-char - c-indicator )
-  | ( ( '?' | ':' | '-' )
-      /* Followed by an ns-plain-safe(c)) */ )
+  ( ( ns-char
+    - c-indicator
+    )
+  | (
+      ( '?'
+      | ':'
+      | '-'
+      )
+      /* Followed by an ns-plain-safe(c) */
+    )
+  )
 ```
 
 
@@ -3861,19 +4015,30 @@ These characters would cause ambiguity with [flow collection] structures.
 ```
 
 ```
-[#] ns-plain-safe-out ::= ns-char
+[#] ns-plain-safe-out ::=
+  ns-char
 ```
 
 ```
 [#] ns-plain-safe-in ::=
-  ns-char - c-flow-indicator
+  ( ns-char
+  - c-flow-indicator
+  )
 ```
 
 ```
 [#] ns-plain-char(c) ::=
-    ( ns-plain-safe(c) - ':' - '#' )
-  | ( /* An ns-char preceding */ '#' )
-  | ( ':' /* Followed by an ns-plain-safe(c) */ )
+  ( ( ns-plain-safe(c)
+    - ':'
+    - '#'
+    )
+  | ( /* An ns-char preceding */
+      '#'
+    )
+  | ( ':'
+      /* Followed by an ns-plain-safe(c) */
+    )
+  )
 ```
 
 
@@ -3927,12 +4092,15 @@ Plain scalars are further restricted to a single line when contained inside an
 
 ```
 [#] nb-ns-plain-in-line(c) ::=
-  ( s-white* ns-plain-char(c) )*
+  ( s-white*
+    ns-plain-char(c)
+  )*
 ```
 
 ```
 [#] ns-plain-one-line(c) ::=
-  ns-plain-first(c) nb-ns-plain-in-line(c)
+  ns-plain-first(c)
+  nb-ns-plain-in-line(c)
 ```
 
 
@@ -3962,7 +4130,8 @@ Empty lines, if any, are consumed as part of the [line folding].
 ```
 [#] s-ns-plain-next-line(n,c) ::=
   s-flow-folded(n)
-  ns-plain-char(c) nb-ns-plain-in-line(c)
+  ns-plain-char(c)
+  nb-ns-plain-in-line(c)
 ```
 
 ```
@@ -4017,8 +4186,10 @@ characters.
 
 ```
 [#] c-flow-sequence(n,c) ::=
-  '[' s-separate(n,c)?
-  ns-s-flow-seq-entries(n,in-flow(c))? ']'
+  '['
+  s-separate(n,c)?
+  ns-s-flow-seq-entries(n,in-flow(c))?
+  ']'
 ```
 
 
@@ -4026,9 +4197,12 @@ Sequence entries are separated by a ["**`,`**"] character.
 
 ```
 [#] ns-s-flow-seq-entries(n,c) ::=
-  ns-flow-seq-entry(n,c) s-separate(n,c)?
-  ( ',' s-separate(n,c)?
-    ns-s-flow-seq-entries(n,c)? )?
+  ns-flow-seq-entry(n,c)
+  s-separate(n,c)?
+  ( ','
+    s-separate(n,c)?
+    ns-s-flow-seq-entries(n,c)?
+  )?
 ```
 
 
@@ -4057,7 +4231,8 @@ sequence entry is a [mapping] with a [single key/value pair].
 
 ```
 [#] ns-flow-seq-entry(n,c) ::=
-  ns-flow-pair(n,c) | ns-flow-node(n,c)
+  ( ns-flow-pair(n,c)
+  | ns-flow-node(n,c) )
 ```
 
 
@@ -4094,8 +4269,10 @@ characters.
 
 ```
 [#] c-flow-mapping(n,c) ::=
-  '{' s-separate(n,c)?
-  ns-s-flow-map-entries(n,in-flow(c))? '}'
+  '{'
+  s-separate(n,c)?
+  ns-s-flow-map-entries(n,in-flow(c))?
+  '}'
 ```
 
 
@@ -4103,9 +4280,12 @@ Mapping entries are separated by a ["**`,`**"] character.
 
 ```
 [#] ns-s-flow-map-entries(n,c) ::=
-  ns-flow-map-entry(n,c) s-separate(n,c)?
-  ( ',' s-separate(n,c)?
-    ns-s-flow-map-entries(n,c)? )?
+  ns-flow-map-entry(n,c)
+  s-separate(n,c)?
+  ( ','
+    s-separate(n,c)?
+    ns-s-flow-map-entries(n,c)?
+  )?
 ```
 
 
@@ -4133,16 +4313,22 @@ entry may be [completely empty].
 
 ```
 [#] ns-flow-map-entry(n,c) ::=
-    ( '?' s-separate(n,c)
-      ns-flow-map-explicit-entry(n,c) )
-  | ns-flow-map-implicit-entry(n,c)
+  (
+    ( '?'
+      s-separate(n,c)
+      ns-flow-map-explicit-entry(n,c)
+    )
+    | ns-flow-map-implicit-entry(n,c)
+  )
 ```
 
 ```
 [#] ns-flow-map-explicit-entry(n,c) ::=
-    ns-flow-map-implicit-entry(n,c)
-  | ( e-node /* Key */
-      e-node /* Value */ )
+  ( ns-flow-map-implicit-entry(n,c)
+  | ( e-node
+      e-node
+    )
+  )
 ```
 
 
@@ -4181,31 +4367,35 @@ indicated by the "**`:`**".
 
 ```
 [#] ns-flow-map-implicit-entry(n,c) ::=
-    ns-flow-map-yaml-key-entry(n,c)
+  ( ns-flow-map-yaml-key-entry(n,c)
   | c-ns-flow-map-empty-key-entry(n,c)
-  | c-ns-flow-map-json-key-entry(n,c)
+  | c-ns-flow-map-json-key-entry(n,c) )
 ```
 
 ```
 [#] ns-flow-map-yaml-key-entry(n,c) ::=
   ns-flow-yaml-node(n,c)
   ( ( s-separate(n,c)?
-      c-ns-flow-map-separate-value(n,c) )
+      c-ns-flow-map-separate-value(n,c)
+    )
   | e-node )
 ```
 
 ```
 [#] c-ns-flow-map-empty-key-entry(n,c) ::=
-  e-node /* Key */
+  e-node
   c-ns-flow-map-separate-value(n,c)
 ```
 
 ```
 [#] c-ns-flow-map-separate-value(n,c) ::=
-  ':' /* Not followed by an
-         ns-plain-safe(c) */
-  ( ( s-separate(n,c) ns-flow-node(n,c) )
-  | e-node /* Value */ )
+  ':'
+  /* Not followed by an ns-plain-safe(c) */
+  ( ( s-separate(n,c)
+      ns-flow-node(n,c)
+    )
+  | e-node
+  )
 ```
 
 
@@ -4245,15 +4435,18 @@ However, as this greatly reduces readability, YAML [processors] should
 [#] c-ns-flow-map-json-key-entry(n,c) ::=
   c-flow-json-node(n,c)
   ( ( s-separate(n,c)?
-      c-ns-flow-map-adjacent-value(n,c) )
+      c-ns-flow-map-adjacent-value(n,c)
+    )
   | e-node )
 ```
 
 ```
 [#] c-ns-flow-map-adjacent-value(n,c) ::=
-  ':' ( ( s-separate(n,c)?
-          ns-flow-node(n,c) )
-      | e-node ) /* Value */
+  ':'
+  ( ( s-separate(n,c)?
+      ns-flow-node(n,c)
+    )
+  | e-node )
 ```
 
 
@@ -4308,9 +4501,13 @@ and the syntax is identical to the general case.
 
 ```
 [#] ns-flow-pair(n,c) ::=
-    ( '?' s-separate(n,c)
-      ns-flow-map-explicit-entry(n,c) )
+  (
+    ( '?'
+      s-separate(n,c)
+      ns-flow-map-explicit-entry(n,c)
+    )
   | ns-flow-pair-entry(n,c)
+  )
 ```
 
 
@@ -4344,9 +4541,9 @@ been impossible to implement.
 
 ```
 [#] ns-flow-pair-entry(n,c) ::=
-    ns-flow-pair-yaml-key-entry(n,c)
+  ( ns-flow-pair-yaml-key-entry(n,c)
   | c-ns-flow-map-empty-key-entry(n,c)
-  | c-ns-flow-pair-json-key-entry(n,c)
+  | c-ns-flow-pair-json-key-entry(n,c) )
 ```
 
 ```
@@ -4363,13 +4560,15 @@ been impossible to implement.
 
 ```
 [#] ns-s-implicit-yaml-key(c) ::=
-  ns-flow-yaml-node(n/a,c) s-separate-in-line?
+  ns-flow-yaml-node(n/a,c)
+  s-separate-in-line?
   /* At most 1024 characters altogether */
 ```
 
 ```
 [#] c-s-implicit-json-key(c) ::=
-  c-flow-json-node(n/a,c) s-separate-in-line?
+  c-flow-json-node(n/a,c)
+  s-separate-in-line?
   /* At most 1024 characters altogether */
 ```
 
@@ -4422,18 +4621,22 @@ Note that none of the "JSON-like" styles is actually acceptable by JSON.
 Even the [double-quoted style] is a superset of the JSON string format.
 
 ```
-[#] ns-flow-yaml-content(n,c) ::= ns-plain(n,c)
+[#] ns-flow-yaml-content(n,c) ::=
+  ns-plain(n,c)
 ```
 
 ```
 [#] c-flow-json-content(n,c) ::=
-    c-flow-sequence(n,c) | c-flow-mapping(n,c)
-  | c-single-quoted(n,c) | c-double-quoted(n,c)
+  ( c-flow-sequence(n,c)
+  | c-flow-mapping(n,c)
+  | c-single-quoted(n,c)
+  | c-double-quoted(n,c) )
 ```
 
 ```
 [#] ns-flow-content(n,c) ::=
-  ns-flow-yaml-content(n,c) | c-flow-json-content(n,c)
+  ( ns-flow-yaml-content(n,c)
+  | c-flow-json-content(n,c) )
 ```
 
 
@@ -4465,28 +4668,40 @@ nodes] which refer to the [anchored] [node properties].
 
 ```
 [#] ns-flow-yaml-node(n,c) ::=
-    c-ns-alias-node
+  ( c-ns-alias-node
   | ns-flow-yaml-content(n,c)
   | ( c-ns-properties(n,c)
-      ( ( s-separate(n,c)
-          ns-flow-yaml-content(n,c) )
-        | e-scalar ) )
+      (
+        ( s-separate(n,c)
+          ns-flow-yaml-content(n,c)
+        )
+        | e-scalar
+      )
+    )
+  )
 ```
 
 ```
 [#] c-flow-json-node(n,c) ::=
-  ( c-ns-properties(n,c) s-separate(n,c) )?
+  ( c-ns-properties(n,c)
+    s-separate(n,c)
+  )?
   c-flow-json-content(n,c)
 ```
 
 ```
 [#] ns-flow-node(n,c) ::=
-    c-ns-alias-node
+  ( c-ns-alias-node
   | ns-flow-content(n,c)
   | ( c-ns-properties(n,c)
-      ( ( s-separate(n,c)
-          ns-flow-content(n,c) )
-        | e-scalar ) )
+      (
+        ( s-separate(n,c)
+          ns-flow-content(n,c)
+        )
+        | e-scalar
+      )
+    )
+  )
 ```
 
 
@@ -4540,10 +4755,14 @@ variables.
 
 ```
 [#] c-b-block-header(m,t) ::=
-  ( ( c-indentation-indicator(m)
-      c-chomping-indicator(t) )
+  (
+    ( c-indentation-indicator(m)
+      c-chomping-indicator(t)
+    )
   | ( c-chomping-indicator(t)
-      c-indentation-indicator(m) ) )
+      c-indentation-indicator(m)
+    )
+  )
   s-b-comment
 ```
 
@@ -4745,7 +4964,9 @@ header].
 
 ```
 [#] l-strip-empty(n) ::=
-  ( s-indent(<=n) b-non-content )*
+  ( s-indent(<=n)
+    b-non-content
+  )*
   l-trail-comments(n)?
 ```
 
@@ -4765,7 +4986,9 @@ constrained.
 
 ```
 [#] l-trail-comments(n) ::=
-  s-indent(<n) c-nb-comment-text b-comment
+  s-indent(<n)
+  c-nb-comment-text
+  b-comment
   l-comment*
 ```
 
@@ -4838,7 +5061,8 @@ It is the simplest, most restricted and most readable [scalar style].
 
 ```
 [#] c-l+literal(n) ::=
-  '|' c-b-block-header(m,t)
+  '|'
+  c-b-block-header(m,t)
   l-literal-content(n+m,t)
 ```
 
@@ -4884,8 +5108,10 @@ In addition, there is no way to break a long literal line.
 
 ```
 [#] l-literal-content(n,t) ::=
-  ( l-nb-literal-text(n) b-nb-literal-next(n)*
-    b-chomped-last(t) )?
+  ( l-nb-literal-text(n)
+    b-nb-literal-next(n)*
+    b-chomped-last(t)
+  )?
   l-chomped-empty(n,t)
 ```
 
@@ -4923,7 +5149,8 @@ It is similar to the [literal style]; however, folded scalars are subject to
 
 ```
 [#] c-l+folded(n) ::=
-  '>' c-b-block-header(m,t)
+  '>'
+  c-b-block-header(m,t)
   l-folded-content(n+m,t)
 ```
 
@@ -4950,13 +5177,17 @@ separates two non-[space] characters.
 
 ```
 [#] s-nb-folded-text(n) ::=
-  s-indent(n) ns-char nb-char*
+  s-indent(n)
+  ns-char
+  nb-char*
 ```
 
 ```
 [#] l-nb-folded-lines(n) ::=
   s-nb-folded-text(n)
-  ( b-l-folded(n,block-in) s-nb-folded-text(n) )*
+  ( b-l-folded(n,block-in)
+    s-nb-folded-text(n)
+  )*
 ```
 
 
@@ -5000,7 +5231,9 @@ Lines starting with [white space] characters (_more-indented_ lines) are not
 
 ```
 [#] s-nb-spaced-text(n) ::=
-  s-indent(n) s-white nb-char*
+  s-indent(n)
+  s-white
+  nb-char*
 ```
 
 ```
@@ -5012,7 +5245,9 @@ Lines starting with [white space] characters (_more-indented_ lines) are not
 ```
 [#] l-nb-spaced-lines(n) ::=
   s-nb-spaced-text(n)
-  ( b-l-spaced(n) s-nb-spaced-text(n) )*
+  ( b-l-spaced(n)
+    s-nb-spaced-text(n)
+  )*
 ```
 
 
@@ -5054,13 +5289,16 @@ also not [folded].
 ```
 [#] l-nb-same-lines(n) ::=
   l-empty(n,block-in)*
-  ( l-nb-folded-lines(n) | l-nb-spaced-lines(n) )
+  ( l-nb-folded-lines(n)
+  | l-nb-spaced-lines(n) )
 ```
 
 ```
 [#] l-nb-diff-lines(n) ::=
   l-nb-same-lines(n)
-  ( b-as-line-feed l-nb-same-lines(n) )*
+  ( b-as-line-feed
+    l-nb-same-lines(n)
+  )*
 ```
 
 
@@ -5101,7 +5339,9 @@ The final [line break] and trailing [empty lines] if any, are subject to
 
 ```
 [#] l-folded-content(n,t) ::=
-  ( l-nb-diff-lines(n) b-chomped-last(t) )?
+  ( l-nb-diff-lines(n)
+    b-chomped-last(t)
+  )?
   l-chomped-empty(n,t)
 ```
 
@@ -5156,13 +5396,16 @@ followed by a non-space character (e.g. "**`-1`**").
 
 ```
 [#] l+block-sequence(n) ::=
-  ( s-indent(n+m) c-l-block-seq-entry(n+m) )+
+  ( s-indent(n+m)
+    c-l-block-seq-entry(n+m)
+  )+
   /* For some fixed auto-detected m > 0 */
 ```
 
 ```
 [#] c-l-block-seq-entry(n) ::=
-  '-' /* Not followed by an ns-char */
+  '-'
+  /* Not followed by an ns-char */
   s-l+block-indented(n,block-in)
 ```
 
@@ -5197,17 +5440,23 @@ Note that it is not possible to specify [node properties] for such a
 
 ```
 [#] s-l+block-indented(n,c) ::=
-    ( s-indent(m)
+  ( ( s-indent(m)
       ( ns-l-compact-sequence(n+1+m)
-      | ns-l-compact-mapping(n+1+m) ) )
+      | ns-l-compact-mapping(n+1+m) )
+    )
   | s-l+block-node(n,c)
-  | ( e-node s-l-comments )
+  | ( e-node
+      s-l-comments
+    )
+  )
 ```
 
 ```
 [#] ns-l-compact-sequence(n) ::=
   c-l-block-seq-entry(n)
-  ( s-indent(n) c-l-block-seq-entry(n) )*
+  ( s-indent(n)
+    c-l-block-seq-entry(n)
+  )*
 ```
 
 
@@ -5242,7 +5491,9 @@ A _Block mapping_ is a series of entries, each [presenting] a [key/value pair].
 
 ```
 [#] l+block-mapping(n) ::=
-  ( s-indent(n+m) ns-l-block-map-entry(n+m) )+
+  ( s-indent(n+m)
+    ns-l-block-map-entry(n+m)
+  )+
   /* For some fixed auto-detected m > 0 */
 ```
 
@@ -5271,8 +5522,8 @@ for [block sequence] entries.
 
 ```
 [#] ns-l-block-map-entry(n) ::=
-    c-l-block-map-explicit-entry(n)
-  | ns-l-block-map-implicit-entry(n)
+  ( c-l-block-map-explicit-entry(n)
+  | ns-l-block-map-implicit-entry(n) )
 ```
 
 ```
@@ -5284,13 +5535,15 @@ for [block sequence] entries.
 
 ```
 [#] c-l-block-map-explicit-key(n) ::=
-  '?' s-l+block-indented(n,block-out)
+  '?'
+  s-l+block-indented(n,block-out)
 ```
 
 ```
 [#] l-block-map-explicit-value(n) ::=
   s-indent(n)
-  ':' s-l+block-indented(n,block-out)
+  ':'
+  s-l+block-indented(n,block-out)
 ```
 
 
@@ -5333,8 +5586,8 @@ single line and must not span more than 1024 Unicode characters.
 
 ```
 [#] ns-s-block-map-implicit-key ::=
-    c-s-implicit-json-key(block-key)
-  | ns-s-implicit-yaml-key(block-key)
+  ( c-s-implicit-json-key(block-key)
+  | ns-s-implicit-yaml-key(block-key) )
 ```
 
 
@@ -5351,8 +5604,12 @@ This prevents a potential ambiguity with multi-line [plain scalars].
 
 ```
 [#] c-l-block-map-implicit-value(n) ::=
-  ':' ( s-l+block-node(n,block-out)
-      | ( e-node s-l-comments ) )
+  ':'
+  ( s-l+block-node(n,block-out)
+  | ( e-node
+      s-l-comments
+    )
+  )
 ```
 
 
@@ -5385,7 +5642,9 @@ mapping.
 ```
 [#] ns-l-compact-mapping(n) ::=
   ns-l-block-map-entry(n)
-  ( s-indent(n) ns-l-block-map-entry(n) )*
+  ( s-indent(n)
+    ns-l-block-map-entry(n)
+  )*
 ```
 
 
@@ -5420,13 +5679,15 @@ scalar] and an [implicit key] starting a nested [block mapping].
 
 ```
 [#] s-l+block-node(n,c) ::=
-  s-l+block-in-block(n,c) | s-l+flow-in-block(n)
+  ( s-l+block-in-block(n,c)
+  | s-l+flow-in-block(n) )
 ```
 
 ```
 [#] s-l+flow-in-block(n) ::=
   s-separate(n+1,flow-out)
-  ns-flow-node(n+1,flow-out) s-l-comments
+  ns-flow-node(n+1,flow-out)
+  s-l-comments
 ```
 
 
@@ -5459,14 +5720,18 @@ entries.
 
 ```
 [#] s-l+block-in-block(n,c) ::=
-  s-l+block-scalar(n,c) | s-l+block-collection(n,c)
+  ( s-l+block-scalar(n,c)
+  | s-l+block-collection(n,c) )
 ```
 
 ```
 [#] s-l+block-scalar(n,c) ::=
   s-separate(n+1,c)
-  ( c-ns-properties(n+1,c) s-separate(n+1,c) )?
-  ( c-l+literal(n) | c-l+folded(n) )
+  ( c-ns-properties(n+1,c)
+    s-separate(n+1,c)
+  )?
+  ( c-l+literal(n)
+  | c-l+folded(n) )
 ```
 
 
@@ -5498,10 +5763,13 @@ versus [**`block-in`** context]).
 
 ```
 [#] s-l+block-collection(n,c) ::=
-  ( s-separate(n+1,c) c-ns-properties(n+1,c) )?
+  ( s-separate(n+1,c)
+    c-ns-properties(n+1,c)
+  )?
   s-l-comments
   ( l+block-sequence(seq-spaces(n,c))
-  | l+block-mapping(n) )
+  | l+block-mapping(n)
+  )
 ```
 
 ```
@@ -5556,7 +5824,8 @@ existence of an actual [document].
 
 ```
 [#] l-document-prefix ::=
-  c-byte-order-mark? l-comment*
+  c-byte-order-mark?
+  l-comment*
 ```
 
 
@@ -5603,25 +5872,29 @@ Obviously, the actual [content] lines are therefore forbidden to begin with
 either of these markers.
 
 ```
-[#] c-directives-end ::=
-  '-' '-' '-'
+[#] c-directives-end ::= "---"
 ```
 
 ```
-[#] c-document-end ::=
-  '.' '.' '.'
+[#] c-document-end ::= "..."
 ```
 
 ```
 [#] l-document-suffix ::=
-  c-document-end s-l-comments
+  c-document-end
+  s-l-comments
 ```
 
 ```
 [#] c-forbidden ::=
   /* Start of line */
-  ( c-directives-end | c-document-end )
-  ( b-char | s-white | /* End of file */ )
+  ( c-directives-end
+  | c-document-end
+  )
+  ( b-char
+  | s-white
+  | /* End of file */
+  )
 ```
 
 
@@ -5697,7 +5970,10 @@ Since the existence of the [document] is indicated by this [marker], the
 [#] l-explicit-document ::=
   c-directives-end
   ( l-bare-document
-  | ( e-node s-l-comments ) )
+  | ( e-node
+      s-l-comments
+    )
+  )
 ```
 
 
@@ -5767,16 +6043,21 @@ following [document] must begin with a [directives end marker] line.
 
 ```
 [#] l-any-document ::=
-    l-directive-document
+  ( l-directive-document
   | l-explicit-document
-  | l-bare-document
+  | l-bare-document )
 ```
 
 ```
 [#] l-yaml-stream ::=
-  l-document-prefix* l-any-document?
-  ( l-document-suffix+ l-document-prefix* l-any-document?
-  | l-document-prefix* l-explicit-document? )*
+  l-document-prefix*
+  l-any-document?
+  ( l-document-suffix+   <!-- fixme -->
+    l-document-prefix*
+    l-any-document?
+  | l-document-prefix*
+    l-explicit-document?
+  )*
 ```
 
 

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -1377,9 +1377,9 @@ prefixes.
 To ensure readability, YAML [streams] use only the _printable_ subset of the
 Unicode character set.
 The allowed character range explicitly excludes the C0 control block[^c0-block]
-**`#x0-#x1F`** (except for TAB **`#x9`**, LF **`#xA`** and CR **`#xD`** which
-are allowed), DEL **`#x7F`**, the C1 control block **`#x80-#x9F`** (except for
-NEL **`#x85`** which is allowed), the surrogate block[^surrogates]
+**`#x00-#x1F`** (except for TAB **`#x09`**, LF **`#x0A`** and CR **`#x0D`**
+which are allowed), DEL **`#x7F`**, the C1 control block **`#x80-#x9F`**
+(except for NEL **`#x85`** which is allowed), the surrogate block[^surrogates]
 **`#xD800-#xDFFF`**, **`#xFFFE`** and **`#xFFFF`**.
 
 On input, a YAML [processor] must accept all characters in this printable
@@ -1396,9 +1396,9 @@ extensive character property tables.
 
 ```
 [#] c-printable ::=
-    #x9 | #xA | #xD | [#x20-#x7E]          /* 8 bit */
+    #x09 | #x0A | #x0D | [#x20-#x7E]       /* 8 bit */
   | #x85 | [#xA0-#xD7FF] | [#xE000-#xFFFD] /* 16 bit */
-  | [#x10000-#x10FFFF]                     /* 32 bit */
+  | [#x010000-#x10FFFF]                    /* 32 bit */
 ```
 
 
@@ -1412,7 +1412,7 @@ YAML [quoted scalars] can.
 
 ```
 [#] nb-json ::=
-  #x9 | [#x20-#x10FFFF]
+  #x09 | [#x20-#x10FFFF]
 ```
 
 > Note: The production name `nb-json` means "non-break JSON compatible" here.
@@ -1826,13 +1826,13 @@ YAML recognizes the following ASCII _line break_ characters.
 
 ```
 [#] b-line-feed ::=
-  #xA    /* LF */
+  #x0A    /* LF */
 ```
 
 
 ```
 [#] b-carriage-return ::=
-  #xD    /* CR */
+  #x0D    /* CR */
 ```
 
 
@@ -1926,7 +1926,7 @@ YAML recognizes two _white space_ characters: _space_ and _tab_.
 
 ```
 [#] s-tab ::=
-  #x9  /* TAB */
+  #x09  /* TAB */
 ```
 
 ```
@@ -2056,59 +2056,59 @@ and non-[printable] characters are not available.
 
 YAML escape sequences are a superset of C's escape sequences:
 
-Escaped ASCII null (**`#x0`**) character.
+Escaped ASCII null (**`#x00`**) character.
 
 ```
 [#] ns-esc-null ::= "0"
 ```
 
 
-Escaped ASCII bell (**`#x7`**) character.
+Escaped ASCII bell (**`#x07`**) character.
 
 ```
 [#] ns-esc-bell ::= "a"
 ```
 
 
-Escaped ASCII backspace (**`#x8`**) character.
+Escaped ASCII backspace (**`#x08`**) character.
 
 ```
 [#] ns-esc-backspace ::= "b"
 ```
 
 
-Escaped ASCII horizontal tab (**`#x9`**) character.
+Escaped ASCII horizontal tab (**`#x09`**) character.
 This is useful at the start or the end of a line to force a leading or trailing
 tab to become part of the [content].
 
 ```
 [#] ns-esc-horizontal-tab ::=
-  "t" | #x9
+  "t" | #x09
 ```
 
 
-Escaped ASCII line feed (**`#xA`**) character.
+Escaped ASCII line feed (**`#x0A`**) character.
 
 ```
 [#] ns-esc-line-feed ::= "n"
 ```
 
 
-Escaped ASCII vertical tab (**`#xB`**) character.
+Escaped ASCII vertical tab (**`#x0B`**) character.
 
 ```
 [#] ns-esc-vertical-tab ::= "v"
 ```
 
 
-Escaped ASCII form feed (**`#xC`**) character.
+Escaped ASCII form feed (**`#x0C`**) character.
 
 ```
 [#] ns-esc-form-feed ::= "f"
 ```
 
 
-Escaped ASCII carriage return (**`#xD`**) character.
+Escaped ASCII carriage return (**`#x0D`**) character.
 
 ```
 [#] ns-esc-carriage-return ::= "r"

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -1305,15 +1305,15 @@ and [flow styles].
 To capture human perception of [indentation] the rules require special
 treatment of the ["**`-`**"] character, used in [block sequences].
 Hence in some cases productions need to behave differently inside [block
-sequences] (_block-in context_) and outside them (_block-out context_).
+sequences] (_BLOCK-IN Context_) and outside them (_BLOCK-OUT context_).
 
 : In [flow styles], explicit [indicators] are used to delineate structure.
 Since plain scalars have no delineating [indicators], they are subject to some
 restrictions to avoid ambiguities.
 These restrictions depend on where they appear: as implicit keys directly
-inside a [block mapping] (_block-key_); as implicit keys inside a [flow
-mapping] (_flow-key_); as values inside a [flow collection] (_flow-in_); or as
-values outside one (_flow-out_).
+inside a [block mapping] (_BLOCK-KEY_); as implicit keys inside a [flow
+mapping] (_FLOW-KEY_); as values inside a [flow collection] (_FLOW-IN_); or as
+values outside one (_FLOW-OUT_).
 
 
 ? (Block) Chomping: `t`
@@ -1398,7 +1398,7 @@ extensive character property tables.
 ```
 [#] c-printable ::=
                          # 8 bit
-  ( x09                  # Tab (\t)
+    x09                  # Tab (\t)
   | x0A                  # Line feed (LF \n)
   | x0D                  # Carriage Return (CR \r)
   | [x20-x7E]            # Printable ASCII
@@ -1407,7 +1407,6 @@ extensive character property tables.
   | [xA0-xD7FF]          # Basic Multilingual Plane (BMP)
   | [xE000-xFFFD]        # Additional Unicode Areas
   | [x010000-x10FFFF]    # 32 bit
-  )
 ```
 
 
@@ -1421,9 +1420,8 @@ YAML [quoted scalars] can.
 
 ```
 [#] nb-json ::=
-  ( x09              # Tab character
+    x09              # Tab character
   | [x20-x10FFFF]    # Non-C0-control characters
-  )
 ```
 
 > Note: The production name `nb-json` means "non-break JSON compatible" here.
@@ -1790,9 +1788,7 @@ grave accent) are _reserved_ for future use.
 
 ```
 [#] c-reserved ::=
-  ( '@'
-  | '`'
-  )
+    '@' | '`'
 ```
 
 
@@ -1816,7 +1812,7 @@ Any indicator character:
 
 ```
 [#] c-indicator ::=
-  ( c-sequence-entry    # '-'
+    c-sequence-entry    # '-'
   | c-mapping-key       # '?'
   | c-mapping-value     # ':'
   | c-collect-entry     # ','
@@ -1834,7 +1830,6 @@ Any indicator character:
   | c-double-quote      # '"'
   | c-directive         # '%'
   | c-reserved          # '@' '`'
-  )
 ```
 
 
@@ -1846,12 +1841,11 @@ This is handled on a case-by-case basis by the relevant productions.
 
 ```
 [#] c-flow-indicator ::=
-  ( c-collect-entry     # ','
+    c-collect-entry     # ','
   | c-sequence-start    # '['
   | c-sequence-end      # ']'
   | c-mapping-start     # '{'
   | c-mapping-end       # '}'
-  )
 ```
 
 
@@ -1871,9 +1865,8 @@ YAML recognizes the following ASCII _line break_ characters.
 
 ```
 [#] b-char ::=
-  ( b-line-feed          # x0A
+    b-line-feed          # x0A
   | b-carriage-return    # X0D
-  )
 ```
 
 
@@ -1893,10 +1886,7 @@ treat these line breaks as non-break characters, with an appropriate warning.
 
 ```
 [#] nb-char ::=
-  ( c-printable
-  - b-char
-  - c-byte-order-mark      # xFEFF
-  )
+  c-printable - b-char - c-byte-order-mark
 ```
 
 
@@ -1905,11 +1895,11 @@ widely used formats.
 
 ```
 [#] b-break ::=
-  ( ( b-carriage-return    # x0A
-      b-line-feed )        # x0D
+    ( b-carriage-return  # x0A
+      b-line-feed
+    )                    # x0D
   | b-carriage-return
   | b-line-feed
-  )
 ```
 
 
@@ -1971,9 +1961,7 @@ YAML recognizes two _white space_ characters: _space_ and _tab_.
 
 ```
 [#] s-white ::=
-  ( s-space
-  | s-tab
-  )
+  s-space | s-tab
 ```
 
 
@@ -1982,9 +1970,7 @@ non-space characters.
 
 ```
 [#] ns-char ::=
-  ( nb-char
-  - s-white
-  )
+  nb-char - s-white
 ```
 
 
@@ -2031,9 +2017,9 @@ A hexadecimal digit for [escape sequences]:
 
 ```
 [#] ns-hex-digit ::=
-  ( ns-dec-digit        # 0-9
+    ns-dec-digit        # 0-9
   | [x41-x46]           # A-F
-  | [x61-x66] )         # a-f
+  | [x61-x66]           # a-f
 ```
 
 
@@ -2041,8 +2027,8 @@ ASCII letter (alphabetic) characters:
 
 ```
 [#] ns-ascii-letter ::=
-  ( [x41-x5A]           # A-Z
-  | [x61-x7A] )         # a-z
+    [x41-x5A]           # A-Z
+  | [x61-x7A]           # a-z
 ```
 
 
@@ -2050,9 +2036,9 @@ Word (alphanumeric) characters for identifiers:
 
 ```
 [#] ns-word-char ::=
-  ( ns-dec-digit        # 0-9
+    ns-dec-digit        # 0-9
   | ns-ascii-letter     # A-Z a-z
-  | '-' )               # '-'
+  | '-'                 # '-'
 ```
 
 URI characters for [tags], as defined in the URI specification[^uri].
@@ -2066,7 +2052,10 @@ YAML [stream], without any processing.
 
 ```
 [#] ns-uri-char ::=
-  ( '%' ns-hex-digit ns-hex-digit  <!-- fixme -->
+    (
+      '%'
+      ns-hex-digit{2}
+    )
   | ns-word-char
   | '#'
   | ';'
@@ -2089,7 +2078,6 @@ YAML [stream], without any processing.
   | ')'
   | '['
   | ']'
-  )
 ```
 
 
@@ -2101,10 +2089,9 @@ These characters would cause ambiguity with [flow collection] structures.
 
 ```
 [#] ns-tag-char ::=
-  ( ns-uri-char
+    ns-uri-char
   - c-tag               # '!'
   - c-flow-indicator
-  )
 ```
 
 
@@ -2155,9 +2142,7 @@ tab to become part of the [content].
 
 ```
 [#] ns-esc-horizontal-tab ::=
-  ( 't'
-  | x09
-  )
+  't' | x09
 ```
 
 
@@ -2286,26 +2271,27 @@ Any escaped character:
 ```
 [#] c-ns-esc-char ::=
   c-escape         # '\'
-  ( ns-esc-null
-  | ns-esc-bell
-  | ns-esc-backspace
-  | ns-esc-horizontal-tab
-  | ns-esc-line-feed
-  | ns-esc-vertical-tab
-  | ns-esc-form-feed
-  | ns-esc-carriage-return
-  | ns-esc-escape
-  | ns-esc-space
-  | ns-esc-double-quote
-  | ns-esc-slash
-  | ns-esc-backslash
-  | ns-esc-next-line
-  | ns-esc-non-breaking-space
-  | ns-esc-line-separator
-  | ns-esc-paragraph-separator
-  | ns-esc-8-bit
-  | ns-esc-16-bit
-  | ns-esc-32-bit
+  (
+      ns-esc-null
+    | ns-esc-bell
+    | ns-esc-backspace
+    | ns-esc-horizontal-tab
+    | ns-esc-line-feed
+    | ns-esc-vertical-tab
+    | ns-esc-form-feed
+    | ns-esc-carriage-return
+    | ns-esc-escape
+    | ns-esc-space
+    | ns-esc-double-quote
+    | ns-esc-slash
+    | ns-esc-backslash
+    | ns-esc-next-line
+    | ns-esc-non-breaking-space
+    | ns-esc-line-separator
+    | ns-esc-paragraph-separator
+    | ns-esc-8-bit
+    | ns-esc-16-bit
+    | ns-esc-32-bit
   )
 ```
 
@@ -2466,8 +2452,8 @@ Separation spaces are a [presentation detail] and must not be used to convey
 
 ```
 [#] s-separate-in-line ::=
-  ( s-white+
-  | /* Start of line */ )
+    s-white+
+  | /* Start of line */
 ```
 
 
@@ -2501,10 +2487,10 @@ Line prefixes are a [presentation detail] and must not be used to convey
 
 ```
 [#] s-line-prefix(n,c) ::=
-  c == block-out => s-block-line-prefix(n)
-  c == block-in  => s-block-line-prefix(n)
-  c == flow-out  => s-flow-line-prefix(n)
-  c == flow-in   => s-flow-line-prefix(n)
+  c == BLOCK-OUT => s-block-line-prefix(n)
+  c == BLOCK-IN  => s-block-line-prefix(n)
+  c == FLOW-OUT  => s-flow-line-prefix(n)
+  c == FLOW-IN   => s-flow-line-prefix(n)
 ```
 
 ```
@@ -2550,8 +2536,9 @@ break].
 
 ```
 [#] l-empty(n,c) ::=
-  ( s-line-prefix(n,c)
-  | s-indent(<n)
+  (
+      s-line-prefix(n,c)
+    | s-indent(<n)
   )
   b-as-line-feed
 ```
@@ -2608,9 +2595,7 @@ A folded non-[empty line] may end with either of the above [line breaks].
 
 ```
 [#] b-l-folded(n,c) ::=
-  ( b-l-trimmed(n,c)
-  | b-as-space
-  )
+  b-l-trimmed(n,c) | b-as-space
 ```
 
 
@@ -2692,7 +2677,7 @@ can be freely [more-indented] without affecting the [content] information.
 ```
 [#] s-flow-folded(n) ::=
   s-separate-in-line?
-  b-l-folded(n,flow-in)
+  b-l-folded(n,FLOW-IN)
   s-flow-line-prefix(n)
 ```
 
@@ -2737,14 +2722,16 @@ However, as this confuses many tools, YAML [processors] should terminate the
 
 ```
 [#] b-comment ::=
-  ( b-non-content
-  | /* End of file */ )
+    b-non-content
+  | /* End of file */
 ```
 
 ```
 [#] s-b-comment ::=
-  ( s-separate-in-line
-    c-nb-comment-text? )?
+  (
+    s-separate-in-line
+    c-nb-comment-text?
+  )?
   b-comment
 ```
 
@@ -2803,8 +2790,10 @@ The only exception is a comment ending a [block scalar header].
 
 ```
 [#] s-l-comments ::=
-  ( s-b-comment
-  | /* Start of line */ )
+  (
+      s-b-comment
+    | /* Start of line */
+  )
   l-comment*
 ```
 
@@ -2840,20 +2829,20 @@ Note that structures following multi-line comment separation must be properly
 
 ```
 [#] s-separate(n,c) ::=
-  c == block-out => s-separate-lines(n)
-  c == block-in  => s-separate-lines(n)
-  c == flow-out  => s-separate-lines(n)
-  c == flow-in   => s-separate-lines(n)
-  c == block-key => s-separate-in-line
-  c == flow-key  => s-separate-in-line
+  c == BLOCK-OUT => s-separate-lines(n)
+  c == BLOCK-IN  => s-separate-lines(n)
+  c == FLOW-OUT  => s-separate-lines(n)
+  c == FLOW-IN   => s-separate-lines(n)
+  c == BLOCK-KEY => s-separate-in-line
+  c == FLOW-KEY  => s-separate-in-line
 ```
 
 ```
 [#] s-separate-lines(n) ::=
-  ( ( s-l-comments
+    ( s-l-comments
       s-flow-line-prefix(n)
     )
-  | s-separate-in-line )
+  | s-separate-in-line
 ```
 
 
@@ -2895,9 +2884,10 @@ information.
 ```
 [#] l-directive ::=
   c-directive            # '%'
-  ( ns-yaml-directive
-  | ns-tag-directive
-  | ns-reserved-directive
+  (
+      ns-yaml-directive
+    | ns-tag-directive
+    | ns-reserved-directive
   )
   s-l-comments
 ```
@@ -2912,7 +2902,8 @@ warning.
 ```
 [#] ns-reserved-directive ::=
   ns-directive-name
-  ( s-separate-in-line
+  (
+    s-separate-in-line
     ns-directive-parameter
   )*
 ```
@@ -3088,10 +3079,9 @@ There are three tag handle variants:
 
 ```
 [#] c-tag-handle ::=
-  ( c-named-tag-handle
+    c-named-tag-handle
   | c-secondary-tag-handle
   | c-primary-tag-handle
-  )
 ```
 
 
@@ -3208,9 +3198,7 @@ There are two _tag prefix_ variants:
 
 ```
 [#] ns-tag-prefix ::=
-  ( c-ns-local-tag-prefix
-  | ns-global-tag-prefix
-  )
+  c-ns-local-tag-prefix | ns-global-tag-prefix
 ```
 
 
@@ -3293,15 +3281,20 @@ Either or both may be omitted.
 
 ```
 [#] c-ns-properties(n,c) ::=
-  ( ( c-ns-tag-property
-      ( s-separate(n,c)
-        c-ns-anchor-property )?
+    (
+      c-ns-tag-property
+      (
+        s-separate(n,c)
+        c-ns-anchor-property
+      )?
     )
-  | ( c-ns-anchor-property
-      ( s-separate(n,c)
-        c-ns-tag-property )?
+  | (
+      c-ns-anchor-property
+      (
+        s-separate(n,c)
+        c-ns-tag-property
+      )?
     )
-  )
 ```
 
 
@@ -3332,10 +3325,9 @@ A tag is denoted by the _"**`!`**" indicator_.
 
 ```
 [#] c-ns-tag-property ::=
-  ( c-verbatim-tag
+    c-verbatim-tag
   | c-ns-shorthand-tag
   | c-non-specific-tag
-  )
 ```
 
 
@@ -3536,9 +3528,7 @@ These characters would cause ambiguity with [flow collection] structures.
 
 ```
 [#] ns-anchor-char ::=
-  ( ns-char
-  - c-flow-indicator
-  )
+    ns-char - c-flow-indicator
 ```
 
 ```
@@ -3624,8 +3614,7 @@ with an empty value.
 Such [nodes] are commonly resolved to a ["**`null`**"] value.
 
 ```
-[#] e-scalar ::=
-  /* Empty */
+[#] e-scalar ::= ""
 ```
 
 
@@ -3660,7 +3649,7 @@ for their existence.
 
 ```
 [#] e-node ::=
-  e-scalar
+  e-scalar    # ""
 ```
 
 
@@ -3703,19 +3692,17 @@ characters.
 
 ```
 [#] nb-double-char ::=
-  ( c-ns-esc-char
-  | ( nb-json
-    - c-escape          # '\'
-    - c-double-quote    # '"'
+    c-ns-esc-char
+  | (
+        nb-json
+      - c-escape          # '\'
+      - c-double-quote    # '"'
     )
-  )
 ```
 
 ```
 [#] ns-double-char ::=
-  ( nb-double-char
-  - s-white
-  )
+  nb-double-char - s-white
 ```
 
 
@@ -3731,10 +3718,10 @@ Double-quoted scalars are restricted to a single line when contained inside an
 
 ```
 [#] nb-double-text(n,c) ::=
-  c == flow-out  => nb-double-multi-line(n)
-  c == flow-in   => nb-double-multi-line(n)
-  c == block-key => nb-double-one-line
-  c == flow-key  => nb-double-one-line
+  c == FLOW-OUT  => nb-double-multi-line(n)
+  c == FLOW-IN   => nb-double-multi-line(n)
+  c == BLOCK-KEY => nb-double-one-line
+  c == FLOW-KEY  => nb-double-one-line
 ```
 
 ```
@@ -3774,15 +3761,14 @@ double-quoted lines to be broken at arbitrary positions.
   s-white*
   c-escape         # '\'
   b-non-content
-  l-empty(n,flow-in)*
+  l-empty(n,FLOW-IN)*
   s-flow-line-prefix(n)
 ```
 
 ```
 [#] s-double-break(n) ::=
-  ( s-double-escaped(n)
+    s-double-escaped(n)
   | s-flow-folded(n)
-  )
 ```
 
 
@@ -3813,7 +3799,8 @@ Empty lines, if any, are consumed as part of the [line folding].
 
 ```
 [#] nb-ns-double-in-line ::=
-  ( s-white*
+  (
+    s-white*
     ns-double-char
   )*
 ```
@@ -3821,9 +3808,11 @@ Empty lines, if any, are consumed as part of the [line folding].
 ```
 [#] s-double-next-line(n) ::=
   s-double-break(n)
-  ( ns-double-char nb-ns-double-in-line
-    ( s-double-next-line(n)
-    | s-white*
+  (
+    ns-double-char nb-ns-double-in-line
+    (
+        s-double-next-line(n)
+      | s-white*
     )
   )?
 ```
@@ -3831,8 +3820,9 @@ Empty lines, if any, are consumed as part of the [line folding].
 ```
 [#] nb-double-multi-line(n) ::=
   nb-ns-double-in-line
-  ( s-double-next-line(n)
-  | s-white*
+  (
+      s-double-next-line(n)
+    | s-white*
   )
 ```
 
@@ -3871,18 +3861,16 @@ In addition, it is only possible to break a long single-quoted line where a
 
 ```
 [#] nb-single-char ::=
-  ( c-quoted-quote
-  | ( nb-json
-    - c-single-quote    # "'"
+    c-quoted-quote
+  | (
+        nb-json
+      - c-single-quote    # "'"
     )
-  )
 ```
 
 ```
 [#] ns-single-char ::=
-  ( nb-single-char
-  - s-white
-  )
+  nb-single-char - s-white
 ```
 
 
@@ -3912,10 +3900,10 @@ Single-quoted scalars are restricted to a single line when contained inside a
 
 ```
 [#] nb-single-text(n,c) ::=
-  c == flow-out  => nb-single-multi-line(n)
-  c == flow-in   => nb-single-multi-line(n)
-  c == block-key => nb-single-one-line
-  c == flow-key  => nb-single-one-line
+  c == FLOW-OUT  => nb-single-multi-line(n)
+  c == FLOW-IN   => nb-single-multi-line(n)
+  c == BLOCK-KEY => nb-single-one-line
+  c == FLOW-KEY  => nb-single-one-line
 ```
 
 ```
@@ -3950,7 +3938,8 @@ Empty lines, if any, are consumed as part of the [line folding].
 
 ```
 [#] nb-ns-single-in-line ::=
-  ( s-white*
+  (
+    s-white*
     ns-single-char
   )*
 ```
@@ -3958,10 +3947,12 @@ Empty lines, if any, are consumed as part of the [line folding].
 ```
 [#] s-single-next-line(n) ::=
   s-flow-folded(n)
-  ( ns-single-char
+  (
+    ns-single-char
     nb-ns-single-in-line
-    ( s-single-next-line(n)
-    | s-white*
+    (
+        s-single-next-line(n)
+      | s-white*
     )
   )?
 ```
@@ -3969,8 +3960,9 @@ Empty lines, if any, are consumed as part of the [line folding].
 ```
 [#] nb-single-multi-line(n) ::=
   nb-ns-single-in-line
-  ( s-single-next-line(n)
-  | s-white*
+  (
+      s-single-next-line(n)
+    | s-white*
   )
 ```
 
@@ -4012,16 +4004,18 @@ causes no ambiguity.
 
 ```
 [#] ns-plain-first(c) ::=
-  ( ( ns-char
-    - c-indicator
+    (
+        ns-char
+      - c-indicator
     )
-  | ( ( c-mapping-key       # '?'
-      | c-mapping-value     #':'
-      | c-sequence-entry    #'-'
+  | (
+      (
+          c-mapping-key       # '?'
+        | c-mapping-value     #':'
+        | c-sequence-entry    #'-'
       )
       /* Followed by an ns-plain-safe(c) */
     )
-  )
 ```
 
 
@@ -4036,10 +4030,10 @@ These characters would cause ambiguity with [flow collection] structures.
 
 ```
 [#] ns-plain-safe(c) ::=
-  c == flow-out  => ns-plain-safe-out
-  c == flow-in   => ns-plain-safe-in
-  c == block-key => ns-plain-safe-out
-  c == flow-key  => ns-plain-safe-in
+  c == FLOW-OUT  => ns-plain-safe-out
+  c == FLOW-IN   => ns-plain-safe-in
+  c == BLOCK-KEY => ns-plain-safe-out
+  c == FLOW-KEY  => ns-plain-safe-in
 ```
 
 ```
@@ -4049,24 +4043,24 @@ These characters would cause ambiguity with [flow collection] structures.
 
 ```
 [#] ns-plain-safe-in ::=
-  ( ns-char
-  - c-flow-indicator
-  )
+  ns-char - c-flow-indicator
 ```
 
 ```
 [#] ns-plain-char(c) ::=
-  ( ( ns-plain-safe(c)
-    - c-mapping-value    # ':'
-    - c-comment          # '#'
+    (
+        ns-plain-safe(c)
+      - c-mapping-value    # ':'
+      - c-comment          # '#'
     )
-  | ( /* An ns-char preceding */
+  | (
+      /* An ns-char preceding */
       c-comment          # '#'
     )
-  | ( c-mapping-value    # ':'
+  | (
+      c-mapping-value    # ':'
       /* Followed by an ns-plain-safe(c) */
     )
-  )
 ```
 
 
@@ -4112,15 +4106,16 @@ Plain scalars are further restricted to a single line when contained inside an
 
 ```
 [#] ns-plain(n,c) ::=
-  c == flow-out  => ns-plain-multi-line(n,c)
-  c == flow-in   => ns-plain-multi-line(n,c)
-  c == block-key => ns-plain-one-line(c)
-  c == flow-key  => ns-plain-one-line(c)
+  c == FLOW-OUT  => ns-plain-multi-line(n,c)
+  c == FLOW-IN   => ns-plain-multi-line(n,c)
+  c == BLOCK-KEY => ns-plain-one-line(c)
+  c == FLOW-KEY  => ns-plain-one-line(c)
 ```
 
 ```
 [#] nb-ns-plain-in-line(c) ::=
-  ( s-white*
+  (
+    s-white*
     ns-plain-char(c)
   )*
 ```
@@ -4189,9 +4184,9 @@ Empty lines, if any, are consumed as part of the [line folding].
 
 ## #. Flow Collection Styles
 
-A _flow collection_ may be nested within a [block collection] ([**`flow-out`**
-context]), nested within another flow collection ([**`flow-in`** context]) or
-be a part of an [implicit key] ([**`flow-key`** context] or [**`block-key`**
+A _flow collection_ may be nested within a [block collection] ([**`FLOW-OUT`**
+context]), nested within another flow collection ([**`FLOW-IN`** context]) or
+be a part of an [implicit key] ([**`FLOW-KEY`** context] or [**`BLOCK-KEY`**
 context]).
 Flow collection entries are terminated by the _"**`,`**" indicator_.
 The final "**`,`**" may be omitted.
@@ -4200,10 +4195,10 @@ This does not cause ambiguity because flow collection entries can never be
 
 ```
 [#] in-flow(c) ::=
-  c == flow-out  => flow-in
-  c == flow-in   => flow-in
-  c == block-key => flow-key
-  c == flow-key  => flow-key
+  c == FLOW-OUT  => FLOW-IN
+  c == FLOW-IN   => FLOW-IN
+  c == BLOCK-KEY => FLOW-KEY
+  c == FLOW-KEY  => FLOW-KEY
 ```
 
 
@@ -4227,7 +4222,8 @@ Sequence entries are separated by a ["**`,`**"] character.
 [#] ns-s-flow-seq-entries(n,c) ::=
   ns-flow-seq-entry(n,c)
   s-separate(n,c)?
-  ( c-collect-entry     # ','
+  (
+    c-collect-entry     # ','
     s-separate(n,c)?
     ns-s-flow-seq-entries(n,c)?
   )?
@@ -4259,9 +4255,7 @@ sequence entry is a [mapping] with a [single key/value pair].
 
 ```
 [#] ns-flow-seq-entry(n,c) ::=
-  ( ns-flow-pair(n,c)
-  | ns-flow-node(n,c)
-  )
+  ns-flow-pair(n,c) | ns-flow-node(n,c)
 ```
 
 
@@ -4311,7 +4305,8 @@ Mapping entries are separated by a ["**`,`**"] character.
 [#] ns-s-flow-map-entries(n,c) ::=
   ns-flow-map-entry(n,c)
   s-separate(n,c)?
-  ( c-collect-entry     # ','
+  (
+    c-collect-entry     # ','
     s-separate(n,c)?
     ns-s-flow-map-entries(n,c)?
   )?
@@ -4342,22 +4337,21 @@ entry may be [completely empty].
 
 ```
 [#] ns-flow-map-entry(n,c) ::=
-  (
-    ( c-mapping-key      # '?'
+    (
+      c-mapping-key      # '?'
       s-separate(n,c)
       ns-flow-map-explicit-entry(n,c)
     )
-    | ns-flow-map-implicit-entry(n,c)
-  )
+  | ns-flow-map-implicit-entry(n,c)
 ```
 
 ```
 [#] ns-flow-map-explicit-entry(n,c) ::=
-  ( ns-flow-map-implicit-entry(n,c)
-  | ( e-node
-      e-node
+    ns-flow-map-implicit-entry(n,c)
+  | (
+      e-node    # ""
+      e-node    # ""
     )
-  )
 ```
 
 
@@ -4396,25 +4390,26 @@ indicated by the "**`:`**".
 
 ```
 [#] ns-flow-map-implicit-entry(n,c) ::=
-  ( ns-flow-map-yaml-key-entry(n,c)
+    ns-flow-map-yaml-key-entry(n,c)
   | c-ns-flow-map-empty-key-entry(n,c)
   | c-ns-flow-map-json-key-entry(n,c)
-  )
 ```
 
 ```
 [#] ns-flow-map-yaml-key-entry(n,c) ::=
   ns-flow-yaml-node(n,c)
-  ( ( s-separate(n,c)?
-      c-ns-flow-map-separate-value(n,c)
-    )
-  | e-node
+  (
+      (
+        s-separate(n,c)?
+        c-ns-flow-map-separate-value(n,c)
+      )
+    | e-node    # ""
   )
 ```
 
 ```
 [#] c-ns-flow-map-empty-key-entry(n,c) ::=
-  e-node
+  e-node    # ""
   c-ns-flow-map-separate-value(n,c)
 ```
 
@@ -4422,10 +4417,12 @@ indicated by the "**`:`**".
 [#] c-ns-flow-map-separate-value(n,c) ::=
   c-mapping-value    # ':'
   /* Not followed by an ns-plain-safe(c) */
-  ( ( s-separate(n,c)
-      ns-flow-node(n,c)
-    )
-  | e-node
+  (
+      (
+        s-separate(n,c)
+        ns-flow-node(n,c)
+      )
+    | e-node    # ""
   )
 ```
 
@@ -4465,20 +4462,24 @@ However, as this greatly reduces readability, YAML [processors] should
 ```
 [#] c-ns-flow-map-json-key-entry(n,c) ::=
   c-flow-json-node(n,c)
-  ( ( s-separate(n,c)?
-      c-ns-flow-map-adjacent-value(n,c)
-    )
-  | e-node
+  (
+      (
+        s-separate(n,c)?
+        c-ns-flow-map-adjacent-value(n,c)
+      )
+    | e-node    # ""
   )
 ```
 
 ```
 [#] c-ns-flow-map-adjacent-value(n,c) ::=
   c-mapping-value          # ':'
-  ( ( s-separate(n,c)?
-      ns-flow-node(n,c)
-    )
-  | e-node
+  (
+      (
+        s-separate(n,c)?
+        ns-flow-node(n,c)
+      )
+    | e-node    # ""
   )
 ```
 
@@ -4534,13 +4535,12 @@ and the syntax is identical to the general case.
 
 ```
 [#] ns-flow-pair(n,c) ::=
-  (
-    ( c-mapping-key      # '?'
+    (
+      c-mapping-key      # '?'
       s-separate(n,c)
       ns-flow-map-explicit-entry(n,c)
     )
   | ns-flow-pair-entry(n,c)
-  )
 ```
 
 
@@ -4574,21 +4574,20 @@ been impossible to implement.
 
 ```
 [#] ns-flow-pair-entry(n,c) ::=
-  ( ns-flow-pair-yaml-key-entry(n,c)
+    ns-flow-pair-yaml-key-entry(n,c)
   | c-ns-flow-map-empty-key-entry(n,c)
   | c-ns-flow-pair-json-key-entry(n,c)
-  )
 ```
 
 ```
 [#] ns-flow-pair-yaml-key-entry(n,c) ::=
-  ns-s-implicit-yaml-key(flow-key)
+  ns-s-implicit-yaml-key(FLOW-KEY)
   c-ns-flow-map-separate-value(n,c)
 ```
 
 ```
 [#] c-ns-flow-pair-json-key-entry(n,c) ::=
-  c-s-implicit-json-key(flow-key)
+  c-s-implicit-json-key(FLOW-KEY)
   c-ns-flow-map-adjacent-value(n,c)
 ```
 
@@ -4661,18 +4660,16 @@ Even the [double-quoted style] is a superset of the JSON string format.
 
 ```
 [#] c-flow-json-content(n,c) ::=
-  ( c-flow-sequence(n,c)
+    c-flow-sequence(n,c)
   | c-flow-mapping(n,c)
   | c-single-quoted(n,c)
   | c-double-quoted(n,c)
-  )
 ```
 
 ```
 [#] ns-flow-content(n,c) ::=
-  ( ns-flow-yaml-content(n,c)
+    ns-flow-yaml-content(n,c)
   | c-flow-json-content(n,c)
-  )
 ```
 
 
@@ -4704,22 +4701,24 @@ nodes] which refer to the [anchored] [node properties].
 
 ```
 [#] ns-flow-yaml-node(n,c) ::=
-  ( c-ns-alias-node
+    c-ns-alias-node
   | ns-flow-yaml-content(n,c)
-  | ( c-ns-properties(n,c)
+  | (
+      c-ns-properties(n,c)
       (
-        ( s-separate(n,c)
-          ns-flow-yaml-content(n,c)
-        )
+          (
+            s-separate(n,c)
+            ns-flow-yaml-content(n,c)
+          )
         | e-scalar
       )
     )
-  )
 ```
 
 ```
 [#] c-flow-json-node(n,c) ::=
-  ( c-ns-properties(n,c)
+  (
+    c-ns-properties(n,c)
     s-separate(n,c)
   )?
   c-flow-json-content(n,c)
@@ -4727,17 +4726,18 @@ nodes] which refer to the [anchored] [node properties].
 
 ```
 [#] ns-flow-node(n,c) ::=
-  ( c-ns-alias-node
+    c-ns-alias-node
   | ns-flow-content(n,c)
-  | ( c-ns-properties(n,c)
+  | (
+      c-ns-properties(n,c)
       (
-        ( s-separate(n,c)
+        (
+          s-separate(n,c)
           ns-flow-content(n,c)
         )
         | e-scalar
       )
     )
-  )
 ```
 
 
@@ -4792,12 +4792,14 @@ variables.
 ```
 [#] c-b-block-header(m,t) ::=
   (
-    ( c-indentation-indicator(m)
-      c-chomping-indicator(t)
-    )
-  | ( c-chomping-indicator(t)
-      c-indentation-indicator(m)
-    )
+      (
+        c-indentation-indicator(m)
+        c-chomping-indicator(t)
+      )
+    | (
+        c-chomping-indicator(t)
+        c-indentation-indicator(m)
+      )
   )
   s-b-comment
 ```
@@ -4851,7 +4853,7 @@ indicator for cases where detection will fail.
 ```
 [#] c-indentation-indicator(m) ::=
   ns-dec-digit => m = ns-dec-digit - x30
-  /* Empty */  => m = auto-detect()
+  ""           => m = auto-detect()
 ```
 
 
@@ -4948,9 +4950,9 @@ convey [content] information.
 
 ```
 [#] c-chomping-indicator(t) ::=
-  '-'         => t = STRIP
-  '+'         => t = KEEP
-  /* Empty */ => t = CLIP
+  '-' => t = STRIP
+  '+' => t = KEEP
+  ""  => t = CLIP
 ```
 
 
@@ -5000,7 +5002,8 @@ header].
 
 ```
 [#] l-strip-empty(n) ::=
-  ( s-indent(<=n)
+  (
+    s-indent(<=n)
     b-non-content
   )*
   l-trail-comments(n)?
@@ -5008,7 +5011,7 @@ header].
 
 ```
 [#] l-keep-empty(n) ::=
-  l-empty(n,block-in)*
+  l-empty(n,BLOCK-IN)*
   l-trail-comments(n)?
 ```
 
@@ -5132,7 +5135,7 @@ In addition, there is no way to break a long literal line.
 
 ```
 [#] l-nb-literal-text(n) ::=
-  l-empty(n,block-in)*
+  l-empty(n,BLOCK-IN)*
   s-indent(n) nb-char+
 ```
 
@@ -5144,7 +5147,8 @@ In addition, there is no way to break a long literal line.
 
 ```
 [#] l-literal-content(n,t) ::=
-  ( l-nb-literal-text(n)
+  (
+    l-nb-literal-text(n)
     b-nb-literal-next(n)*
     b-chomped-last(t)
   )?
@@ -5221,7 +5225,8 @@ separates two non-[space] characters.
 ```
 [#] l-nb-folded-lines(n) ::=
   s-nb-folded-text(n)
-  ( b-l-folded(n,block-in)
+  (
+    b-l-folded(n,BLOCK-IN)
     s-nb-folded-text(n)
   )*
 ```
@@ -5275,13 +5280,14 @@ Lines starting with [white space] characters (_more-indented_ lines) are not
 ```
 [#] b-l-spaced(n) ::=
   b-as-line-feed
-  l-empty(n,block-in)*
+  l-empty(n,BLOCK-IN)*
 ```
 
 ```
 [#] l-nb-spaced-lines(n) ::=
   s-nb-spaced-text(n)
-  ( b-l-spaced(n)
+  (
+    b-l-spaced(n)
     s-nb-spaced-text(n)
   )*
 ```
@@ -5324,16 +5330,18 @@ also not [folded].
 
 ```
 [#] l-nb-same-lines(n) ::=
-  l-empty(n,block-in)*
-  ( l-nb-folded-lines(n)
-  | l-nb-spaced-lines(n)
+  l-empty(n,BLOCK-IN)*
+  (
+      l-nb-folded-lines(n)
+    | l-nb-spaced-lines(n)
   )
 ```
 
 ```
 [#] l-nb-diff-lines(n) ::=
   l-nb-same-lines(n)
-  ( b-as-line-feed
+  (
+    b-as-line-feed
     l-nb-same-lines(n)
   )*
 ```
@@ -5376,7 +5384,8 @@ The final [line break] and trailing [empty lines] if any, are subject to
 
 ```
 [#] l-folded-content(n,t) ::=
-  ( l-nb-diff-lines(n)
+  (
+    l-nb-diff-lines(n)
     b-chomped-last(t)
   )?
   l-chomped-empty(n,t)
@@ -5433,7 +5442,8 @@ followed by a non-space character (e.g. "**`-1`**").
 
 ```
 [#] l+block-sequence(n) ::=
-  ( s-indent(n+m)
+  (
+    s-indent(n+m)
     c-l-block-seq-entry(n+m)
   )+
   /* For some fixed auto-detected m > 0 */
@@ -5443,7 +5453,7 @@ followed by a non-space character (e.g. "**`-1`**").
 [#] c-l-block-seq-entry(n) ::=
   c-sequence-entry    # '-'
   /* Not followed by an ns-char */
-  s-l+block-indented(n,block-in)
+  s-l+block-indented(n,BLOCK-IN)
 ```
 
 
@@ -5477,22 +5487,25 @@ Note that it is not possible to specify [node properties] for such a
 
 ```
 [#] s-l+block-indented(n,c) ::=
-  ( ( s-indent(m)
-      ( ns-l-compact-sequence(n+1+m)
-      | ns-l-compact-mapping(n+1+m)
+    (
+      s-indent(m)
+      (
+          ns-l-compact-sequence(n+1+m)
+        | ns-l-compact-mapping(n+1+m)
       )
     )
   | s-l+block-node(n,c)
-  | ( e-node
+  | (
+      e-node    # ""
       s-l-comments
     )
-  )
 ```
 
 ```
 [#] ns-l-compact-sequence(n) ::=
   c-l-block-seq-entry(n)
-  ( s-indent(n)
+  (
+    s-indent(n)
     c-l-block-seq-entry(n)
   )*
 ```
@@ -5529,7 +5542,8 @@ A _Block mapping_ is a series of entries, each [presenting] a [key/value pair].
 
 ```
 [#] l+block-mapping(n) ::=
-  ( s-indent(n+m)
+  (
+    s-indent(n+m)
     ns-l-block-map-entry(n+m)
   )+
   /* For some fixed auto-detected m > 0 */
@@ -5560,30 +5574,30 @@ for [block sequence] entries.
 
 ```
 [#] ns-l-block-map-entry(n) ::=
-  ( c-l-block-map-explicit-entry(n)
+    c-l-block-map-explicit-entry(n)
   | ns-l-block-map-implicit-entry(n)
-  )
 ```
 
 ```
 [#] c-l-block-map-explicit-entry(n) ::=
   c-l-block-map-explicit-key(n)
-  ( l-block-map-explicit-value(n)
-  | e-node
+  (
+      l-block-map-explicit-value(n)
+    | e-node    # ""
   )
 ```
 
 ```
 [#] c-l-block-map-explicit-key(n) ::=
   c-mapping-key                      # '?'
-  s-l+block-indented(n,block-out)
+  s-l+block-indented(n,BLOCK-OUT)
 ```
 
 ```
 [#] l-block-map-explicit-value(n) ::=
   s-indent(n)
   c-mapping-value    # ':'
-  s-l+block-indented(n,block-out)
+  s-l+block-indented(n,BLOCK-OUT)
 ```
 
 
@@ -5619,17 +5633,17 @@ single line and must not span more than 1024 Unicode characters.
 
 ```
 [#] ns-l-block-map-implicit-entry(n) ::=
-  ( ns-s-block-map-implicit-key
-  | e-node
+  (
+      ns-s-block-map-implicit-key
+    | e-node    # ""
   )
   c-l-block-map-implicit-value(n)
 ```
 
 ```
 [#] ns-s-block-map-implicit-key ::=
-  ( c-s-implicit-json-key(block-key)
-  | ns-s-implicit-yaml-key(block-key)
-  )
+    c-s-implicit-json-key(BLOCK-KEY)
+  | ns-s-implicit-yaml-key(BLOCK-KEY)
 ```
 
 
@@ -5647,10 +5661,12 @@ This prevents a potential ambiguity with multi-line [plain scalars].
 ```
 [#] c-l-block-map-implicit-value(n) ::=
   c-mapping-value                  # ':'
-  ( s-l+block-node(n,block-out)
-  | ( e-node
-      s-l-comments
-    )
+  (
+      s-l+block-node(n,BLOCK-OUT)
+    | (
+        e-node    # ""
+        s-l-comments
+      )
   )
 ```
 
@@ -5684,7 +5700,8 @@ mapping.
 ```
 [#] ns-l-compact-mapping(n) ::=
   ns-l-block-map-entry(n)
-  ( s-indent(n)
+  (
+    s-indent(n)
     ns-l-block-map-entry(n)
   )*
 ```
@@ -5721,15 +5738,14 @@ scalar] and an [implicit key] starting a nested [block mapping].
 
 ```
 [#] s-l+block-node(n,c) ::=
-  ( s-l+block-in-block(n,c)
+    s-l+block-in-block(n,c)
   | s-l+flow-in-block(n)
-  )
 ```
 
 ```
 [#] s-l+flow-in-block(n) ::=
-  s-separate(n+1,flow-out)
-  ns-flow-node(n+1,flow-out)
+  s-separate(n+1,FLOW-OUT)
+  ns-flow-node(n+1,FLOW-OUT)
   s-l-comments
 ```
 
@@ -5763,19 +5779,20 @@ entries.
 
 ```
 [#] s-l+block-in-block(n,c) ::=
-  ( s-l+block-scalar(n,c)
+    s-l+block-scalar(n,c)
   | s-l+block-collection(n,c)
-  )
 ```
 
 ```
 [#] s-l+block-scalar(n,c) ::=
   s-separate(n+1,c)
-  ( c-ns-properties(n+1,c)
+  (
+    c-ns-properties(n+1,c)
     s-separate(n+1,c)
   )?
-  ( c-l+literal(n)
-  | c-l+folded(n)
+  (
+      c-l+literal(n)
+    | c-l+folded(n)
   )
 ```
 
@@ -5803,24 +5820,26 @@ folded:↓
 
 Since people perceive the ["**`-`**" indicator] as [indentation], nested [block
 sequences] may be [indented] by one less [space] to compensate, except, of
-course, if nested inside another [block sequence] ([**`block-out`** context]
-versus [**`block-in`** context]).
+course, if nested inside another [block sequence] ([**`BLOCK-OUT`** context]
+versus [**`BLOCK-IN`** context]).
 
 ```
 [#] s-l+block-collection(n,c) ::=
-  ( s-separate(n+1,c)
+  (
+    s-separate(n+1,c)
     c-ns-properties(n+1,c)
   )?
   s-l-comments
-  ( l+block-sequence(seq-spaces(n,c))
-  | l+block-mapping(n)
+  (
+      l+block-sequence(seq-spaces(n,c))
+    | l+block-mapping(n)
   )
 ```
 
 ```
 [#] seq-spaces(n,c) ::=
-  c == block-out => n-1
-  c == block-in  => n
+  c == BLOCK-OUT => n-1
+  c == BLOCK-IN  => n
 ```
 
 
@@ -5933,12 +5952,14 @@ either of these markers.
 ```
 [#] c-forbidden ::=
   /* Start of line */
-  ( c-directives-end
-  | c-document-end
+  (
+      c-directives-end
+    | c-document-end
   )
-  ( b-char
-  | s-white
-  | /* End of file */
+  (
+      b-char
+    | s-white
+    | /* End of file */
   )
 ```
 
@@ -5977,7 +5998,7 @@ document's [node] to be [indented] at zero or more [spaces].
 
 ```
 [#] l-bare-document ::=
-  s-l+block-node(-1,block-in)
+  s-l+block-node(-1,BLOCK-IN)
   /* Excluding c-forbidden content */
 ```
 
@@ -6014,10 +6035,12 @@ Since the existence of the [document] is indicated by this [marker], the
 ```
 [#] l-explicit-document ::=
   c-directives-end
-  ( l-bare-document
-  | ( e-node
-      s-l-comments
-    )
+  (
+      l-bare-document
+    | (
+        e-node    # ""
+        s-l-comments
+      )
   )
 ```
 
@@ -6088,21 +6111,25 @@ following [document] must begin with a [directives end marker] line.
 
 ```
 [#] l-any-document ::=
-  ( l-directive-document
+    l-directive-document
   | l-explicit-document
   | l-bare-document
-  )
 ```
 
 ```
 [#] l-yaml-stream ::=
   l-document-prefix*
   l-any-document?
-  ( l-document-suffix+   <!-- fixme -->
-    l-document-prefix*
-    l-any-document?
-  | l-document-prefix*
-    l-explicit-document?
+  (
+      (
+        l-document-suffix+
+        l-document-prefix*
+        l-any-document?
+      )
+    | (
+        l-document-prefix*
+        l-explicit-document?
+      )
   )*
 ```
 

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -2501,10 +2501,10 @@ Line prefixes are a [presentation detail] and must not be used to convey
 
 ```
 [#] s-line-prefix(n,c) ::=
-  c = block-out => s-block-line-prefix(n)
-  c = block-in  => s-block-line-prefix(n)
-  c = flow-out  => s-flow-line-prefix(n)
-  c = flow-in   => s-flow-line-prefix(n)
+  c == block-out => s-block-line-prefix(n)
+  c == block-in  => s-block-line-prefix(n)
+  c == flow-out  => s-flow-line-prefix(n)
+  c == flow-in   => s-flow-line-prefix(n)
 ```
 
 ```
@@ -2840,12 +2840,12 @@ Note that structures following multi-line comment separation must be properly
 
 ```
 [#] s-separate(n,c) ::=
-  c = block-out => s-separate-lines(n)
-  c = block-in  => s-separate-lines(n)
-  c = flow-out  => s-separate-lines(n)
-  c = flow-in   => s-separate-lines(n)
-  c = block-key => s-separate-in-line
-  c = flow-key  => s-separate-in-line
+  c == block-out => s-separate-lines(n)
+  c == block-in  => s-separate-lines(n)
+  c == flow-out  => s-separate-lines(n)
+  c == flow-in   => s-separate-lines(n)
+  c == block-key => s-separate-in-line
+  c == flow-key  => s-separate-in-line
 ```
 
 ```
@@ -3731,10 +3731,10 @@ Double-quoted scalars are restricted to a single line when contained inside an
 
 ```
 [#] nb-double-text(n,c) ::=
-  c = flow-out  => nb-double-multi-line(n)
-  c = flow-in   => nb-double-multi-line(n)
-  c = block-key => nb-double-one-line
-  c = flow-key  => nb-double-one-line
+  c == flow-out  => nb-double-multi-line(n)
+  c == flow-in   => nb-double-multi-line(n)
+  c == block-key => nb-double-one-line
+  c == flow-key  => nb-double-one-line
 ```
 
 ```
@@ -3912,10 +3912,10 @@ Single-quoted scalars are restricted to a single line when contained inside a
 
 ```
 [#] nb-single-text(n,c) ::=
-  c = flow-out  => nb-single-multi-line(n)
-  c = flow-in   => nb-single-multi-line(n)
-  c = block-key => nb-single-one-line
-  c = flow-key  => nb-single-one-line
+  c == flow-out  => nb-single-multi-line(n)
+  c == flow-in   => nb-single-multi-line(n)
+  c == block-key => nb-single-one-line
+  c == flow-key  => nb-single-one-line
 ```
 
 ```
@@ -4036,10 +4036,10 @@ These characters would cause ambiguity with [flow collection] structures.
 
 ```
 [#] ns-plain-safe(c) ::=
-  c = flow-out  => ns-plain-safe-out
-  c = flow-in   => ns-plain-safe-in
-  c = block-key => ns-plain-safe-out
-  c = flow-key  => ns-plain-safe-in
+  c == flow-out  => ns-plain-safe-out
+  c == flow-in   => ns-plain-safe-in
+  c == block-key => ns-plain-safe-out
+  c == flow-key  => ns-plain-safe-in
 ```
 
 ```
@@ -4112,10 +4112,10 @@ Plain scalars are further restricted to a single line when contained inside an
 
 ```
 [#] ns-plain(n,c) ::=
-  c = flow-out  => ns-plain-multi-line(n,c)
-  c = flow-in   => ns-plain-multi-line(n,c)
-  c = block-key => ns-plain-one-line(c)
-  c = flow-key  => ns-plain-one-line(c)
+  c == flow-out  => ns-plain-multi-line(n,c)
+  c == flow-in   => ns-plain-multi-line(n,c)
+  c == block-key => ns-plain-one-line(c)
+  c == flow-key  => ns-plain-one-line(c)
 ```
 
 ```
@@ -4200,10 +4200,10 @@ This does not cause ambiguity because flow collection entries can never be
 
 ```
 [#] in-flow(c) ::=
-  c = flow-out  => flow-in
-  c = flow-in   => flow-in
-  c = block-key => flow-key
-  c = flow-key  => flow-key
+  c == flow-out  => flow-in
+  c == flow-in   => flow-in
+  c == block-key => flow-key
+  c == flow-key  => flow-key
 ```
 
 
@@ -4948,9 +4948,9 @@ convey [content] information.
 
 ```
 [#] c-chomping-indicator(t) ::=
-  '-'         => t = strip
-  '+'         => t = keep
-  /* Empty */ => t = clip
+  '-'         => t = STRIP
+  '+'         => t = KEEP
+  /* Empty */ => t = CLIP
 ```
 
 
@@ -4959,9 +4959,9 @@ by the chomping indicator specified in the [block scalar header].
 
 ```
 [#] b-chomped-last(t) ::=
-  t = strip => b-non-content | /* End of file */
-  t = clip  => b-as-line-feed | /* End of file */
-  t = keep  => b-as-line-feed | /* End of file */
+  t == STRIP => b-non-content  | /* End of file */
+  t == CLIP  => b-as-line-feed | /* End of file */
+  t == KEEP  => b-as-line-feed | /* End of file */
 ```
 
 
@@ -4993,9 +4993,9 @@ header].
 
 ```
 [#] l-chomped-empty(n,t) ::=
-  t = strip => l-strip-empty(n)
-  t = clip  => l-strip-empty(n)
-  t = keep  => l-keep-empty(n)
+  t == STRIP => l-strip-empty(n)
+  t == CLIP  => l-strip-empty(n)
+  t == KEEP  => l-keep-empty(n)
 ```
 
 ```
@@ -5819,8 +5819,8 @@ versus [**`block-in`** context]).
 
 ```
 [#] seq-spaces(n,c) ::=
-  c = block-out => n-1
-  c = block-in  => n
+  c == block-out => n-1
+  c == block-in  => n
 ```
 
 


### PR DESCRIPTION
These commits make various formatting changes to the spec productions with the intent to add clarity.

They were originally included in #158 which makes more in depth changes to the productions.

They were relocated here in order to be reviewed separately and more easily.