### PR TITLE
Fix for `c-indentation-indicator`

### DIFF
--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -4902,7 +4902,7 @@ where detection will fail.
 
 ```
 [#] c-indentation-indicator ::=
-  ns-dec-digit
+  [x31-x39]    # 1-9
 ```
 
 


### PR DESCRIPTION
The explicit indentation indicator always meant `1-9`.

This fixes a bug based on a faulty interpretation of the 1.2.1 version.