### PR TITLE
Add non-whitespace lookaheads

### DIFF
--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -2549,10 +2549,11 @@ Line prefixes are a [presentation detail] and must not be used to convey
 [content] information.
 
 ```
-[#] s-line-prefix(n,BLOCK-OUT) ::= s-block-line-prefix(n)
-    s-line-prefix(n,BLOCK-IN)  ::= s-block-line-prefix(n)
-    s-line-prefix(n,FLOW-OUT)  ::= s-flow-line-prefix(n)
-    s-line-prefix(n,FLOW-IN)   ::= s-flow-line-prefix(n)
+[#]
+s-line-prefix(n,BLOCK-OUT) ::= s-block-line-prefix(n)
+s-line-prefix(n,BLOCK-IN)  ::= s-block-line-prefix(n)
+s-line-prefix(n,FLOW-OUT)  ::= s-flow-line-prefix(n)
+s-line-prefix(n,FLOW-IN)   ::= s-flow-line-prefix(n)
 ```
 
 ```
@@ -2890,12 +2891,13 @@ Note that structures following multi-line comment separation must be properly
 [comment] lines themselves.
 
 ```
-[#] s-separate(n,BLOCK-OUT) ::= s-separate-lines(n)
-    s-separate(n,BLOCK-IN)  ::= s-separate-lines(n)
-    s-separate(n,FLOW-OUT)  ::= s-separate-lines(n)
-    s-separate(n,FLOW-IN)   ::= s-separate-lines(n)
-    s-separate(n,BLOCK-KEY) ::= s-separate-in-line
-    s-separate(n,FLOW-KEY)  ::= s-separate-in-line
+[#]
+s-separate(n,BLOCK-OUT) ::= s-separate-lines(n)
+s-separate(n,BLOCK-IN)  ::= s-separate-lines(n)
+s-separate(n,FLOW-OUT)  ::= s-separate-lines(n)
+s-separate(n,FLOW-IN)   ::= s-separate-lines(n)
+s-separate(n,BLOCK-KEY) ::= s-separate-in-line
+s-separate(n,FLOW-KEY)  ::= s-separate-in-line
 ```
 
 ```
@@ -3776,10 +3778,11 @@ Double-quoted scalars are restricted to a single line when contained inside an
 ```
 
 ```
-[#] nb-double-text(n,FLOW-OUT)  ::= nb-double-multi-line(n)
-    nb-double-text(n,FLOW-IN)   ::= nb-double-multi-line(n)
-    nb-double-text(n,BLOCK-KEY) ::= nb-double-one-line
-    nb-double-text(n,FLOW-KEY)  ::= nb-double-one-line
+[#]
+nb-double-text(n,FLOW-OUT)  ::= nb-double-multi-line(n)
+nb-double-text(n,FLOW-IN)   ::= nb-double-multi-line(n)
+nb-double-text(n,BLOCK-KEY) ::= nb-double-one-line
+nb-double-text(n,FLOW-KEY)  ::= nb-double-one-line
 ```
 
 ```
@@ -3957,10 +3960,11 @@ Single-quoted scalars are restricted to a single line when contained inside a
 ```
 
 ```
-[#] nb-single-text(FLOW-OUT)  ::= nb-single-multi-line(n)
-    nb-single-text(FLOW-IN)   ::= nb-single-multi-line(n)
-    nb-single-text(BLOCK-KEY) ::= nb-single-one-line
-    nb-single-text(FLOW-KEY)  ::= nb-single-one-line
+[#]
+nb-single-text(FLOW-OUT)  ::= nb-single-multi-line(n)
+nb-single-text(FLOW-IN)   ::= nb-single-multi-line(n)
+nb-single-text(BLOCK-KEY) ::= nb-single-one-line
+nb-single-text(FLOW-KEY)  ::= nb-single-one-line
 ```
 
 ```
@@ -4068,8 +4072,8 @@ ambiguity.
   | (
       (
           c-mapping-key       # '?'
-        | c-mapping-value     #':'
-        | c-sequence-entry    #'-'
+        | c-mapping-value     # ':'
+        | c-sequence-entry    # '-'
       )
       [ lookahead = ns-plain-safe(c) ]
     )
@@ -4084,10 +4088,11 @@ scalars must not contain the "`[`", "`]`", "`{`", "`}`" and "`,`" characters.
 These characters would cause ambiguity with [flow collection] structures.
 
 ```
-[#] ns-plain-safe(FLOW-OUT)  ::= ns-plain-safe-out
-    ns-plain-safe(FLOW-IN)   ::= ns-plain-safe-in
-    ns-plain-safe(BLOCK-KEY) ::= ns-plain-safe-out
-    ns-plain-safe(FLOW-KEY)  ::= ns-plain-safe-in
+[#]
+ns-plain-safe(FLOW-OUT)  ::= ns-plain-safe-out
+ns-plain-safe(FLOW-IN)   ::= ns-plain-safe-in
+ns-plain-safe(BLOCK-KEY) ::= ns-plain-safe-out
+ns-plain-safe(FLOW-KEY)  ::= ns-plain-safe-in
 ```
 
 ```
@@ -4159,10 +4164,11 @@ Plain scalars are further restricted to a single line when contained inside an
 [implicit key].
 
 ```
-[#] ns-plain(n,FLOW-OUT)  ::= ns-plain-multi-line(n,FLOW-OUT)
-    ns-plain(n,FLOW-IN)   ::= ns-plain-multi-line(n,FLOW-IN)
-    ns-plain(n,BLOCK-KEY) ::= ns-plain-one-line(BLOCK-KEY)
-    ns-plain(n,FLOW-KEY)  ::= ns-plain-one-line(FLOW-KEY)
+[#]
+ns-plain(n,FLOW-OUT)  ::= ns-plain-multi-line(n,FLOW-OUT)
+ns-plain(n,FLOW-IN)   ::= ns-plain-multi-line(n,FLOW-IN)
+ns-plain(n,BLOCK-KEY) ::= ns-plain-one-line(BLOCK-KEY)
+ns-plain(n,FLOW-KEY)  ::= ns-plain-one-line(FLOW-KEY)
 ```
 
 ```
@@ -4246,10 +4252,11 @@ This does not cause ambiguity because flow collection entries can never be
 [completely empty].
 
 ```
-[#] in-flow(n,FLOW-OUT)  ::= ns-s-flow-seq-entries(n,FLOW-IN)
-    in-flow(n,FLOW-IN)   ::= ns-s-flow-seq-entries(n,FLOW-IN)
-    in-flow(n,BLOCK-KEY) ::= ns-s-flow-seq-entries(n,FLOW-KEY)
-    in-flow(n,FLOW-KEY)  ::= ns-s-flow-seq-entries(n,FLOW-KEY)
+[#]
+in-flow(n,FLOW-OUT)  ::= ns-s-flow-seq-entries(n,FLOW-IN)
+in-flow(n,FLOW-IN)   ::= ns-s-flow-seq-entries(n,FLOW-IN)
+in-flow(n,BLOCK-KEY) ::= ns-s-flow-seq-entries(n,FLOW-KEY)
+in-flow(n,FLOW-KEY)  ::= ns-s-flow-seq-entries(n,FLOW-KEY)
 ```
 
 
@@ -5001,9 +5008,10 @@ The chomping method used is a [presentation detail] and must not be used to
 convey [content] information.
 
 ```
-[#] c-chomping-indicator(STRIP) ::= '-'
-    c-chomping-indicator(KEEP)  ::= '+'
-    c-chomping-indicator(CLIP)  ::= ""
+[#]
+c-chomping-indicator(STRIP) ::= '-'
+c-chomping-indicator(KEEP)  ::= '+'
+c-chomping-indicator(CLIP)  ::= ""
 ```
 
 
@@ -5045,9 +5053,10 @@ also controlled by the chomping indicator specified in the [block scalar
 header].
 
 ```
-[#] l-chomped-empty(n,STRIP) ::= l-strip-empty(n)
-    l-chomped-empty(n,CLIP)  ::= l-strip-empty(n)
-    l-chomped-empty(n,KEEP)  ::= l-keep-empty(n)
+[#]
+l-chomped-empty(n,STRIP) ::= l-strip-empty(n)
+l-chomped-empty(n,CLIP)  ::= l-strip-empty(n)
+l-chomped-empty(n,KEEP)  ::= l-keep-empty(n)
 ```
 
 ```

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -5011,10 +5011,10 @@ The interpretation of the final [line break] of a [block scalar] is controlled
 by the chomping indicator specified in the [block scalar header].
 
 ```
-[#] b-chomped-last(t) ::=
-    b-chomped-last(STRIP) ::= b-non-content  | <end-of-input>
-    b-chomped-last(CLIP)  ::= b-as-line-feed | <end-of-input>
-    b-chomped-last(KEEP)  ::= b-as-line-feed | <end-of-input>
+[#]
+b-chomped-last(STRIP) ::= b-non-content  | <end-of-input>
+b-chomped-last(CLIP)  ::= b-as-line-feed | <end-of-input>
+b-chomped-last(KEEP)  ::= b-as-line-feed | <end-of-input>
 ```
 
 

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -5635,6 +5635,7 @@ for [block sequence] entries.
 ```
 [#] c-l-block-map-explicit-key(n) ::=
   c-mapping-key                      # '?'
+  [lookahead ≠ ns-char]
   s-l+block-indented(n,BLOCK-OUT)
 ```
 

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -1271,11 +1271,12 @@ term is either:
     whose Unicode code point is within that range.
   * The name of a production (`c-printable`), which matches that production.
 * A lookaround:
-  * `[lookahead = term]`, which matches the empty string if `term` would match.
-  * `[lookahead ≠ term]`, which matches the empty string if `term` would not
+  * `[ lookahead = term ]`, which matches the empty string if `term` would
     match.
-  * `[lookbehind = term]`, which matches the empty string if `term` would match
-    beginning at any prior point on the line and ending at the current
+  * `[ lookahead ≠ term ]`, which matches the empty string if `term` would not
+    match.
+  * `[ lookbehind = term ]`, which matches the empty string if `term` would
+    match beginning at any prior point on the line and ending at the current
     position.
 * A special production:
   * `<start-of-line>`, which matches the empty string at the beginning of a
@@ -4070,7 +4071,7 @@ ambiguity.
         | c-mapping-value     #':'
         | c-sequence-entry    #'-'
       )
-      [lookahead = ns-plain-safe(c)]
+      [ lookahead = ns-plain-safe(c) ]
     )
 ```
 
@@ -4107,12 +4108,12 @@ These characters would cause ambiguity with [flow collection] structures.
       - c-comment          # '#'
     )
   | (
-      [lookbehind = ns-char]
+      [ lookbehind = ns-char ]
       c-comment          # '#'
     )
   | (
       c-mapping-value    # ':'
-      [lookahead = ns-plain-safe(c)]
+      [ lookahead = ns-plain-safe(c) ]
     )
 ```
 
@@ -4465,7 +4466,7 @@ indicated by the "`:`".
 ```
 [#] c-ns-flow-map-separate-value(n,c) ::=
   c-mapping-value    # ':'
-  [lookahead ≠ ns-plain-safe(c)]
+  [ lookahead ≠ ns-plain-safe(c) ]
   (
       (
         s-separate(n,c)
@@ -5498,7 +5499,7 @@ followed by a non-space character (e.g. "`-42`").
 ```
 [#] c-l-block-seq-entry(n) ::=
   c-sequence-entry    # '-'
-  [lookahead ≠ ns-char]
+  [ lookahead ≠ ns-char ]
   s-l+block-indented(n,BLOCK-IN)
 ```
 
@@ -5635,7 +5636,7 @@ for [block sequence] entries.
 ```
 [#] c-l-block-map-explicit-key(n) ::=
   c-mapping-key                      # '?'
-  [lookahead ≠ ns-char]
+  [ lookahead ≠ ns-char ]
   s-l+block-indented(n,BLOCK-OUT)
 ```
 

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -4388,7 +4388,8 @@ entry may be [completely empty].
 ```
 [#] ns-flow-map-entry(n,c) ::=
     (
-      c-mapping-key      # '?'
+      c-mapping-key             # '?'
+      [ lookahead ≠ ns-char ]   # Not followed by non-whitespace
       s-separate(n,c)
       ns-flow-map-explicit-entry(n,c)
     )
@@ -4585,7 +4586,8 @@ the syntax is identical to the general case.
 ```
 [#] ns-flow-pair(n,c) ::=
     (
-      c-mapping-key      # '?'
+      c-mapping-key             # '?'
+      [ lookahead ≠ ns-char ]   # Not followed by non-whitespace
       s-separate(n,c)
       ns-flow-map-explicit-entry(n,c)
     )
@@ -5498,8 +5500,8 @@ followed by a non-space character (e.g. "`-42`").
 
 ```
 [#] c-l-block-seq-entry(n) ::=
-  c-sequence-entry    # '-'
-  [ lookahead ≠ ns-char ]
+  c-sequence-entry                  # '-'
+  [ lookahead ≠ ns-char ]           # Not followed by non-whitespace
   s-l+block-indented(n,BLOCK-IN)
 ```
 
@@ -5629,21 +5631,22 @@ for [block sequence] entries.
   c-l-block-map-explicit-key(n)
   (
       l-block-map-explicit-value(n)
-    | e-node    # ""
+    | e-node                        # ""
   )
 ```
 
 ```
 [#] c-l-block-map-explicit-key(n) ::=
-  c-mapping-key                      # '?'
-  [ lookahead ≠ ns-char ]
+  c-mapping-key                     # '?'
+  [ lookahead ≠ ns-char ]           # Not followed by non-whitespace
   s-l+block-indented(n,BLOCK-OUT)
 ```
 
 ```
 [#] l-block-map-explicit-value(n) ::=
   s-indent(n)
-  c-mapping-value    # ':'
+  c-mapping-value                   # ':'
+  [ lookahead ≠ ns-char ]           # Not followed by non-whitespace
   s-l+block-indented(n,BLOCK-OUT)
 ```
 
@@ -5707,7 +5710,8 @@ This prevents a potential ambiguity with multi-line [plain scalars].
 
 ```
 [#] c-l-block-map-implicit-value(n) ::=
-  c-mapping-value                  # ':'
+  c-mapping-value           # ':'
+  [ lookahead ≠ ns-char ]   # Not followed by non-whitespace
   (
       s-l+block-node(n,BLOCK-OUT)
     | (
@@ -5986,7 +5990,9 @@ either of these markers.
 ```
 
 ```
-[#] c-document-end ::= "..."
+[#] c-document-end ::=
+  "..."
+  [ lookahead ≠ ns-char ]   # Not followed by non-whitespace
 ```
 
 ```


### PR DESCRIPTION
These lookaheads do not change the grammar but they make the rules easier to understand and parsers easy to be efficient.

Originally in #187 but moved here to leave the hard part there.