### PR TITLE
Add missing error case in content indentation rules

### DIFF
--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -4891,8 +4891,8 @@ If no indentation indicator is given, then the content indentation level is
 equal to the number of leading [spaces] on the first non-[empty line] of the
 contents.
 
-A block scalar may have an _indentation indicator_, which is a single decimal
-digit indicating the indentation level of the content.
+It is an error if any line containing block scalar content does not begin with
+a number of spaces equal to at least the content indentation level.
 
 It is an error for any of the leading [empty lines] to contain more [spaces]
 than the first non-[empty line].

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -4881,7 +4881,7 @@ This is the only case where a [comment] must not be followed by additional
 
 Every block scalar has a _content indentation level_.
 The content of the block scalar excludes a number of leading [spaces] on each
-line that is less than or equal to the content indentation level.
+line up to the content indentation level.
 
 If a block scalar has an _indentation indicator_, then the content indentation
 level of the block scalar is equal to the indentation level of the block scalar

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -4881,18 +4881,20 @@ This is the only case where a [comment] must not be followed by additional
 
 Every block scalar has a _content indentation level_.
 The content of the block scalar excludes a number of leading [spaces] on each
-line equal to the content indentation level.
+line that is less than or equal to the content indentation level.
 
 If a block scalar has an _indentation indicator_, then the content indentation
 level of the block scalar is equal to the indentation level of the block scalar
-plus the value of the indentation indicator.
+plus the integer value of the indentation indicator character.
 
 If no indentation indicator is given, then the content indentation level is
 equal to the number of leading [spaces] on the first non-[empty line] of the
 contents.
+If there is no non-[empty line] then the content indentation level is equal to
+the number of spaces on the longest line.
 
-It is an error if any line containing block scalar content does not begin with
-a number of spaces equal to at least the content indentation level.
+It is an error if any non-[empty line] does not begin with a number of spaces
+greater than or equal to the content indentation level.
 
 It is an error for any of the leading [empty lines] to contain more [spaces]
 than the first non-[empty line].


### PR DESCRIPTION
After the grammar changes, the grammar itself no longer enforces that block scalar content indentation must match the indentation indicator. I intended to add this restriction to 8.1.1.1 Block Indentation Indicator, but I inadvertently left it out. This PR adds it.

Also, this PR removes a redundant sentence that was inadvertently left in. The remainder of the section does properly define the indentation indicator:

> If a block scalar has an _indentation indicator_, then the content indentation
level of the block scalar is equal to the indentation level of the block scalar
plus the value of the indentation indicator.