### PR TITLE
Use definition lists in glossary

### DIFF
--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -52,18 +52,18 @@ Comment
 Text in a YAML file that is typically intended for humans to read, but not
 considered part of the YAML data model.
 Comment text may be discarded entirely by a parser.
-It may also be reported as events and stored in the DOM or possibly in a
-native data structure.
+It may also be reported as events and stored in the DOM or possibly in a native
+data structure.
 Syntactically, comments are text starting with a `#` character and continuing
 to the end of the line.
 :
-Comments may be used within YAML documents or before/between/after them (in
-the YAML stream).
+Comments may be used within YAML documents or before/between/after them (in the
+YAML stream).
 
 Composer
 :
-A composer is the processor in a load stack that gets events from a parser
-and uses them to create the DOM state.
+A composer is the processor in a load stack that gets events from a parser and
+uses them to create the DOM state.
 
 Constructor
 :
@@ -82,8 +82,8 @@ YAML data model.
 Document
 :
 A document is a top level YAML node.
-Most YAML files consist of a single YAML document, although they may also
-have zero or multiple documents.
+Most YAML files consist of a single YAML document, although they may also have
+zero or multiple documents.
 
 Double quoted scalar
 :
@@ -94,15 +94,15 @@ They use a number of escape sequences to represent non-printable characters.
 
 DOM
 :
-A DOM is an information state that is a tree of nodes created by a composer
-or a representer and consumed by a constructor or a serializer.
+A DOM is an information state that is a tree of nodes created by a composer or
+a representer and consumed by a constructor or a serializer.
 A DOM may also be consumed directly by an application.
-A DOM API can offer a lot more information and processing options than a
-native data structure.
+A DOM API can offer a lot more information and processing options than a native
+data structure.
 :
 Frameworks do not need to implement a DOM as part of their stacks, as long as
-they adhere to the YAML specification rules for moving information through
-the DOM.
+they adhere to the YAML specification rules for moving information through the
+DOM.
 
 Dumper / Dump
 :
@@ -111,8 +111,8 @@ information all the way from native to file states.
 
 Dump Stack
 :
-The set of processors that move YAML information from a native state to a
-file state.
+The set of processors that move YAML information from a native state to a file
+state.
 
 ## E
 
@@ -144,8 +144,8 @@ Event types include:
 
 File
 :
-File is the term for YAML information in a final textual state, external to
-the YAML stack.
+File is the term for YAML information in a final textual state, external to the
+YAML stack.
 A YAML framework loads from a file and dumps to a file.
 The term is abstract and doesn't have to be a file stored to disk.
 It might be a socket or other external data source/target.
@@ -154,8 +154,8 @@ Flow / Flow Collection Style
 :
 In YAML, mappings and sequences can be represented in a style that uses curly
 braces and square brackets in the same manner that JSON does.
-Block collections may contain any collection nodes in the flow style, but
-flow collections may only contain collections in the flow style.
+Block collections may contain any collection nodes in the flow style, but flow
+collections may only contain collections in the flow style.
 
 Folded Scalar Style
 :
@@ -168,9 +168,9 @@ Framework / YAML Framework
 :
 A full YAML processing implementation in a given programming language.
 A framework almost always has at least a Loader and a Dumper.
-A complete, full-featured YAML framework would also support things like
-schema processors, path referencing, DOM API and standard library support,
-among many other details.
+A complete, full-featured YAML framework would also support things like schema
+processors, path referencing, DOM API and standard library support, among many
+other details.
 
 ## H
 
@@ -208,8 +208,8 @@ A kind should not be confused with a type.
 Library
 :
 The DOM resolves tags to functions.
-These functions come from the library that is registered to the DOM; often
-the YAML standard library.
+These functions come from the library that is registered to the DOM; often the
+YAML standard library.
 
 List
 :
@@ -257,8 +257,8 @@ An alias may be used for any node.
 
 Native / Native Object
 :
-A language specific state that is the final result of a loader, or the
-initial state given to a dumper.
+A language specific state that is the final result of a loader, or the initial
+state given to a dumper.
 This state is defined by the programming language being used, or maybe a form
 crafted by the author of the application.
 Some YAML frameworks may use the DOM state as their native state.
@@ -287,23 +287,21 @@ Parser / Parse
 A parser is the processor in the load stack that reads tokens, matches them
 against a grammar and write events.
 It may also throw an error if the tokens don't match the grammar.
-The events are usually consumed by the composer to create a DOM, but they
-might also be processed directly by a streaming application.
+The events are usually consumed by the composer to create a DOM, but they might
+also be processed directly by a streaming application.
 
 Plain Scalar
 :
 Plain refers to the quoting style of a scalar where the value is unquoted; as
 opposed to single/double quoted or literal or folded styles.
-A scalar-value event contains a flag as to whether the scalar was plain or
-not.
+A scalar-value event contains a flag as to whether the scalar was plain or not.
 Plain scalars are often assigned tags based on their content value.
 
 Processor
 :
 A component in the load stack or dump stack to transforms data from one state
 to another.
-Load stack processors include: reader, lexer, parser, composer and
-constructor.
+Load stack processors include: reader, lexer, parser, composer and constructor.
 Dump stack processors include: representer, serializer, emitter, streamer and
 writer.
 
@@ -340,8 +338,8 @@ information, a YAML schema can alter the semantic meaning of a YAML file.
 :
 In YAML 1.2, schemas are almost always expressed in the source code of the
 framework.
-In future versions, a YAML Schema language can be used to control the
-behavior of a framework (if the framework supports it).
+In future versions, a YAML Schema language can be used to control the behavior
+of a framework (if the framework supports it).
 
 Sequence
 :
@@ -360,8 +358,8 @@ The single quotes must be escaped using two single quotes (`''`).
 
 Stack / YAML Stack
 :
-YAML processing occurs as 2 stacks of processors, each moving data (in
-opposite directions) between YAML formatted text and computer memory states.
+YAML processing occurs as 2 stacks of processors, each moving data (in opposite
+directions) between YAML formatted text and computer memory states.
 They are called the load stack and the dump stack.
 Collectively the 2 stacks may be referred to as "the YAML stack".
 
@@ -378,14 +376,14 @@ and consumed by a composer or an emitter.
 
 Stream (Character Stream)
 :
-The set of unicode characters produced by a reader or streamer and consumed
-by a lexer or writer.
+The set of unicode characters produced by a reader or streamer and consumed by
+a lexer or writer.
 
 Stream (YAML Stream or Document Stream)
 :
 A YAML file is considered a "stream" of zero or more documents.
-A stream may also have directives and/or comments before, between or after
-the documents.
+A stream may also have directives and/or comments before, between or after the
+documents.
 This is the typical meaning when the word "stream" is used with no qualifier.
 
 Streamer
@@ -395,8 +393,8 @@ It simply joins tokens into a character stream.
 
 String
 :
-String is a heavily overloaded term in YAML and depends on the context in
-which it is used.
+String is a heavily overloaded term in YAML and depends on the context in which
+it is used.
 
 Style
 :
@@ -411,8 +409,8 @@ Tag
 :
 A tag is an annotation on a node.
 Tags are identifers preceded by a `!`, like `!foo` or `!!str`.
-A tag identifier is used to identify a function that will be applied to a
-node when it is retrieved from the DOM.
+A tag identifier is used to identify a function that will be applied to a node
+when it is retrieved from the DOM.
 The function's return type is can be considered the "type" of the node.
 :
 While tags may be written explicitly into a YAML file using the `!abc` syntax,

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -10,37 +10,37 @@ meanings.
 ## A
 
 Alias
-
-: An alias is a reference to another YAML node.
+:
+An alias is a reference to another YAML node.
 It similar to a pointer in the C programming language.
 The alias `*foo` is a reference to a node with an anchor `&foo`.
 
 Anchor
-
-: An anchor is a label attached to a node.
+:
+An anchor is a label attached to a node.
 The node can be used elsewhere by referencing it with an alias.
 A node with the anchor `&foo` can be referenced elsewhere with the alias
 `*foo`.
 
 Application
-
-: An end user program using a YAML framework.
+:
+An end user program using a YAML framework.
 
 Array
-
-: The word array is sometimes used to refer to a native data structure
-typically constructed from a sequence node.
+:
+The word array is sometimes used to refer to a native data structure typically
+constructed from a sequence node.
 
 ## B
 
 Block / Block Collection Style
-
-: Block collections are written in the indentation-based scoping style that
-YAML is most known for.
+:
+Block collections are written in the indentation-based scoping style that YAML
+is most known for.
 
 Boolean
-
-: Boolean is a native state consisting of the values true and false.
+:
+Boolean is a native state consisting of the values true and false.
 Most constructors/schemas support booleans.
 It is typical for a schema to use the plain scalars `true` and `false` to
 assign the boolean tag function.
@@ -48,125 +48,125 @@ assign the boolean tag function.
 ## C
 
 Comment
-
-: Text in a YAML file that is typically intended for humans to read, but not
+:
+Text in a YAML file that is typically intended for humans to read, but not
 considered part of the YAML data model.
 Comment text may be discarded entirely by a parser.
 It may also be reported as events and stored in the DOM or possibly in a
 native data structure.
 Syntactically, comments are text starting with a `#` character and continuing
 to the end of the line.
-
-  Comments may be used within YAML documents or before/between/after them (in
+:
+Comments may be used within YAML documents or before/between/after them (in
 the YAML stream).
 
 Composer
-
-: A composer is the processor in a load stack that gets events from a parser
+:
+A composer is the processor in a load stack that gets events from a parser
 and uses them to create the DOM state.
 
 Constructor
-
-: A constructor is the processor in a load stack that iterates over a DOM tree
+:
+A constructor is the processor in a load stack that iterates over a DOM tree
 and creates a native representation.
 
 ## D
 
 Directive
-
-: A directive is an instruction to the parser.
+:
+A directive is an instruction to the parser.
 YAML 1.2 defines 2 directives: `%YAML ...` and `%TAG ...`.
 Directives are part of a YAML stream, but not part of YAML documents or the
 YAML data model.
 
 Document
-
-: A document is a top level YAML node.
+:
+A document is a top level YAML node.
 Most YAML files consist of a single YAML document, although they may also
 have zero or multiple documents.
 
 Double quoted scalar
-
-: Scalar values written in the double quote style are capable of expressing any
+:
+Scalar values written in the double quote style are capable of expressing any
 possible string value.
 The double quoted style is the only scalar style capable of that.
 They use a number of escape sequences to represent non-printable characters.
 
 DOM
-
-: A DOM is an information state that is a tree of nodes created by a composer
+:
+A DOM is an information state that is a tree of nodes created by a composer
 or a representer and consumed by a constructor or a serializer.
 A DOM may also be consumed directly by an application.
 A DOM API can offer a lot more information and processing options than a
 native data structure.
-
-  Frameworks do not need to implement a DOM as part of their stacks, as long as
+:
+Frameworks do not need to implement a DOM as part of their stacks, as long as
 they adhere to the YAML specification rules for moving information through
 the DOM.
 
 Dumper / Dump
-
-: A dumper is a processor that links all the processors of a dump stack, taking
+:
+A dumper is a processor that links all the processors of a dump stack, taking
 information all the way from native to file states.
 
 Dump Stack
-
-: The set of processors that move YAML information from a native state to a
+:
+The set of processors that move YAML information from a native state to a
 file state.
 
 ## E
 
 Emitter / Emit
-
-: An emitter is the process in the dump stack that turns events into tokens.
+:
+An emitter is the process in the dump stack that turns events into tokens.
 In the dump stack the events come from the serializer.
 In stream processing the events would come from an application filter process
 that would typically be reading events from a parser.
 
 Event
-
-: An event is an information state produced by a parser or serializer and
+:
+An event is an information state produced by a parser or serializer and
 consumed by a composer or emitter.
 Event types include:
-
-  * stream-start
-  * stream-end
-  * document-start
-  * document-end
-  * mapping-start
-  * mapping-end
-  * sequence-start
-  * sequence-end
-  * scalar-value
-  * alias-name
+:
+* stream-start
+* stream-end
+* document-start
+* document-end
+* mapping-start
+* mapping-end
+* sequence-start
+* sequence-end
+* scalar-value
+* alias-name
 
 ## F
 
 File
-
-: File is the term for YAML information in a final textual state, external to
+:
+File is the term for YAML information in a final textual state, external to
 the YAML stack.
 A YAML framework loads from a file and dumps to a file.
 The term is abstract and doesn't have to be a file stored to disk.
 It might be a socket or other external data source/target.
 
 Flow / Flow Collection Style
-
-: In YAML, mappings and sequences can be represented in a style that uses curly
+:
+In YAML, mappings and sequences can be represented in a style that uses curly
 braces and square brackets in the same manner that JSON does.
 Block collections may contain any collection nodes in the flow style, but
 flow collections may only contain collections in the flow style.
 
 Folded Scalar Style
-
-: Folded scalars occur only in block collections.
+:
+Folded scalars occur only in block collections.
 They are indicated by a greater-than sign.
 The indented lines that follow replace newlines with a space, and two or more
 consecutive newlines with n-1 literal newlines.
 
 Framework / YAML Framework
-
-: A full YAML processing implementation in a given programming language.
+:
+A full YAML processing implementation in a given programming language.
 A framework almost always has at least a Loader and a Dumper.
 A complete, full-featured YAML framework would also support things like
 schema processors, path referencing, DOM API and standard library support,
@@ -175,21 +175,21 @@ among many other details.
 ## H
 
 Hash
-
-: The word hash is sometimes used to refer to a native data structure typically
+:
+The word hash is sometimes used to refer to a native data structure typically
 constructed from a mapping node.
 
 ## I
 
 Information
-
-: Any of the various data bits flowing through a YAML stack.
+:
+Any of the various data bits flowing through a YAML stack.
 
 ## J
 
 JSON
-
-: When used with the JSON Schema or a derivative of that schema, YAML is a
+:
+When used with the JSON Schema or a derivative of that schema, YAML is a
 syntactic and semantic superset of the JSON data format.
 That is, a YAML loader using such a schema (which is typical) can load a JSON
 file and produce the same result as a JSON loading (often called `parse`)
@@ -198,56 +198,56 @@ process.
 ## K
 
 Kind
-
-: There are 3 kinds of nodes in YAML: mappings, sequences and scalars.
+:
+There are 3 kinds of nodes in YAML: mappings, sequences and scalars.
 A kind refers to the raw structure.
 A kind should not be confused with a type.
 
 ## L
 
 Library
-
-: The DOM resolves tags to functions.
+:
+The DOM resolves tags to functions.
 These functions come from the library that is registered to the DOM; often
 the YAML standard library.
 
 List
-
-: A list is a property of a type.
+:
+A list is a property of a type.
 List types are often made from sequence nodes, but they can be result of any
 tag function whose return type is a list type.
 
 Literal / Literal Scalar Style
-
-: The literal scalar is similar to the heredoc style found in some programming
+:
+The literal scalar is similar to the heredoc style found in some programming
 languages like Perl and Bash.
 No character escaping is allowed and newlines are literal.
 Any valid YAML file's content can be encoded in the literal style by simply
 indenting it.
 
 Loader / Load
-
-: A dumper is a processor that links all the processors of a dump stack, taking
+:
+A dumper is a processor that links all the processors of a dump stack, taking
 information all the way from native to file states.
 
 Load Stack
-
-: The set of processors that move YAML information from the file state to the
+:
+The set of processors that move YAML information from the file state to the
 native state: read, lex, parse, compose, construct.
 
 ## M
 
 Mapping
-
-: A mapping is a kind of YAML node that consists of a set of zero or more
+:
+A mapping is a kind of YAML node that consists of a set of zero or more
 key/value pairs.
 Any kind of node is allowed to be a key, even though native models rarely
 support this.
 Equivalent keys (if they can be detected) are not supported.
 
 Model / Data Model
-
-: This word describes elementary kinds of data that YAML represents.
+:
+This word describes elementary kinds of data that YAML represents.
 A YAML file is a stream of YAML documents each of which have one root node.
 Nodes may be mappings, sequences or scalars.
 Nodes may be annotated with anchors and/or tags.
@@ -256,51 +256,51 @@ An alias may be used for any node.
 ## N
 
 Native / Native Object
-
-: A language specific state that is the final result of a loader, or the
+:
+A language specific state that is the final result of a loader, or the
 initial state given to a dumper.
 This state is defined by the programming language being used, or maybe a form
 crafted by the author of the application.
 Some YAML frameworks may use the DOM state as their native state.
-
-  As an example, in Python, generic native states include dictionaries, lists,
+:
+As an example, in Python, generic native states include dictionaries, lists,
 tuples and values.
 Custom native states include the instance objects of Python classes.
 
 Node
-
-: A node is an addressable point in a YAML document.
+:
+A node is an addressable point in a YAML document.
 Mappings, sequences, scalars are nodes.
 An alias is a reference to a node.
 Anchors and tags are annotations to nodes.
 
 Null
-
-: Null is a native value supported by most schemas.
+:
+Null is a native value supported by most schemas.
 The plain value `null` as well as the plain empty value is most often used to
 represent it.
 
 ## P
 
 Parser / Parse
-
-: A parser is the processor in the load stack that reads tokens, matches them
+:
+A parser is the processor in the load stack that reads tokens, matches them
 against a grammar and write events.
 It may also throw an error if the tokens don't match the grammar.
 The events are usually consumed by the composer to create a DOM, but they
 might also be processed directly by a streaming application.
 
 Plain Scalar
-
-: Plain refers to the quoting style of a scalar where the value is unquoted; as
+:
+Plain refers to the quoting style of a scalar where the value is unquoted; as
 opposed to single/double quoted or literal or folded styles.
 A scalar-value event contains a flag as to whether the scalar was plain or
 not.
 Plain scalars are often assigned tags based on their content value.
 
 Processor
-
-: A component in the load stack or dump stack to transforms data from one state
+:
+A component in the load stack or dump stack to transforms data from one state
 to another.
 Load stack processors include: reader, lexer, parser, composer and
 constructor.
@@ -310,97 +310,97 @@ writer.
 ## R
 
 Reader / Read
-
-: A reader is a processor in the load stack that reads a file and produces a
+:
+A reader is a processor in the load stack that reads a file and produces a
 stream of unicode characters.
 
 Reference
-
-: A reference can be thought of as a pointer to another node in the DOM.
+:
+A reference can be thought of as a pointer to another node in the DOM.
 In YAML 1.2 the only references are aliases.
 
 Representer / Represent
-
-: A representer is a process that turns native programming data into a YAML DOM
+:
+A representer is a process that turns native programming data into a YAML DOM
 state.
 
 ## S
 
 Scalar
-
-: A scalar is a a leaf node that contains exactly one value.
+:
+A scalar is a a leaf node that contains exactly one value.
 Strings, numbers and booean values are examples of scalars.
 
 Schema
-
-: Schema in YAML refers to all the external information required to process a
+:
+Schema in YAML refers to all the external information required to process a
 YAML stream.
 Unlike traditional schemas which typically enforce the structural typing of
 information, a YAML schema can alter the semantic meaning of a YAML file.
-
-  In YAML 1.2, schemas are almost always expressed in the source code of the
+:
+In YAML 1.2, schemas are almost always expressed in the source code of the
 framework.
 In future versions, a YAML Schema language can be used to control the
 behavior of a framework (if the framework supports it).
 
 Sequence
-
-: A sequence is a collection node that consists of zero or more nodes.
+:
+A sequence is a collection node that consists of zero or more nodes.
 
 Serializer / Serialize
-
-: A serializer is the process in the dump stack that iterates over the DOM and
+:
+A serializer is the process in the dump stack that iterates over the DOM and
 produces events that are typically sent to an emitter.
 
 Single quoted scalar
-
-: Scalar values written in the single quote style can contain any sequence of
+:
+Scalar values written in the single quote style can contain any sequence of
 printable characters except the single quote itself.
 The single quotes must be escaped using two single quotes (`''`).
 
 Stack / YAML Stack
-
-: YAML processing occurs as 2 stacks of processors, each moving data (in
+:
+YAML processing occurs as 2 stacks of processors, each moving data (in
 opposite directions) between YAML formatted text and computer memory states.
 They are called the load stack and the dump stack.
 Collectively the 2 stacks may be referred to as "the YAML stack".
 
 Standard Library
-
-: Versions of YAML after 1.2 define a standard library of tag functions.
+:
+Versions of YAML after 1.2 define a standard library of tag functions.
 
 State
-
-: A form that YAML information is in during various stages of the stack.
+:
+A form that YAML information is in during various stages of the stack.
 States include: files, characters, tokens, events, DOMs and native objects.
 For instance an "event" is a data state produced by a parser or a serializer,
 and consumed by a composer or an emitter.
 
 Stream (Character Stream)
-
-: The set of unicode characters produced by a reader or streamer and consumed
+:
+The set of unicode characters produced by a reader or streamer and consumed
 by a lexer or writer.
 
 Stream (YAML Stream or Document Stream)
-
-: A YAML file is considered a "stream" of zero or more documents.
+:
+A YAML file is considered a "stream" of zero or more documents.
 A stream may also have directives and/or comments before, between or after
 the documents.
 This is the typical meaning when the word "stream" is used with no qualifier.
 
 Streamer
-
-: This is the dump stack sister process to the lexer.
+:
+This is the dump stack sister process to the lexer.
 It simply joins tokens into a character stream.
 
 String
-
-: String is a heavily overloaded term in YAML and depends on the context in
+:
+String is a heavily overloaded term in YAML and depends on the context in
 which it is used.
 
 Style
-
-: YAML has multiple styles to represent collections and scalars.
+:
+YAML has multiple styles to represent collections and scalars.
 Collection styles are "block" and "flow".
 Scalar styles are "plain", "single quoted", "double quoted", "literal" and
 "folded".
@@ -408,41 +408,41 @@ Scalar styles are "plain", "single quoted", "double quoted", "literal" and
 ## T
 
 Tag
-
-: A tag is an annotation on a node.
+:
+A tag is an annotation on a node.
 Tags are identifers preceded by a `!`, like `!foo` or `!!str`.
 A tag identifier is used to identify a function that will be applied to a
 node when it is retrieved from the DOM.
 The function's return type is can be considered the "type" of the node.
-
-  While tags may be written explicitly into a YAML file using the `!abc`
-syntax, it is quite common for tags to be added to nodes implicitly according
-to the rules of a schema.
+:
+While tags may be written explicitly into a YAML file using the `!abc` syntax,
+it is quite common for tags to be added to nodes implicitly according to the
+rules of a schema.
 
 Token
-
-: A token is a piece of information that is produced by a lexer or emitter.
+:
+A token is a piece of information that is produced by a lexer or emitter.
 A token has a name and a value.
 The value is a sequence of zero or more contiguous characters from (or for) a
 character stream.
 
 Type
-
-: A type is a set of constraints on a node.
+:
+A type is a set of constraints on a node.
 Types are defined by schemas.
 
 ## W
 
 Writer / Write
-
-: A writer is the processor in a dump stack that encodes unicode characters and
+:
+A writer is the processor in a dump stack that encodes unicode characters and
 writes them to a file state.
 
 ## Y
 
 YAML
-
-: YAML is a programming-language-agnostic data serialization language.
+:
+YAML is a programming-language-agnostic data serialization language.
 "YAML" rhymes with "camel".
 YAML is a recursive backronym that stands for "YAML Ain't Markup Language".
 People often think YAML is Yet Another Markup Language, but it Ain't!

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -9,125 +9,125 @@ meanings.
 
 ## A
 
-* Alias
+Alias
 
-  An alias is a reference to another YAML node.
-  It similar to a pointer in the C programming language.
-  The alias `*foo` is a reference to a node with an anchor `&foo`.
+: An alias is a reference to another YAML node.
+It similar to a pointer in the C programming language.
+The alias `*foo` is a reference to a node with an anchor `&foo`.
 
-* Anchor
+Anchor
 
-  An anchor is a label attached to a node.
-  The node can be used elsewhere by referencing it with an alias.
-  A node with the anchor `&foo` can be referenced elsewhere with the alias
-  `*foo`.
+: An anchor is a label attached to a node.
+The node can be used elsewhere by referencing it with an alias.
+A node with the anchor `&foo` can be referenced elsewhere with the alias
+`*foo`.
 
-* Application
+Application
 
-  An end user program using a YAML framework.
+: An end user program using a YAML framework.
 
-* Array
+Array
 
-  The word array is sometimes used to refer to a native data structure
-  typically constructed from a sequence node.
+: The word array is sometimes used to refer to a native data structure
+typically constructed from a sequence node.
 
 ## B
 
-* Block / Block Collection Style
+Block / Block Collection Style
 
-  Block collections are written in the indentation-based scoping style that
-  YAML is most known for.
+: Block collections are written in the indentation-based scoping style that
+YAML is most known for.
 
-* Boolean
+Boolean
 
-  Boolean is a native state consisting of the values true and false.
-  Most constructors/schemas support booleans.
-  It is typical for a schema to use the plain scalars `true` and `false` to
-  assign the boolean tag function.
+: Boolean is a native state consisting of the values true and false.
+Most constructors/schemas support booleans.
+It is typical for a schema to use the plain scalars `true` and `false` to
+assign the boolean tag function.
 
 ## C
 
-* Comment
+Comment
 
-  Text in a YAML file that is typically intended for humans to read, but not
-  considered part of the YAML data model.
-  Comment text may be discarded entirely by a parser.
-  It may also be reported as events and stored in the DOM or possibly in a
-  native data structure.
-  Syntactically, comments are text starting with a `#` character and continuing
-  to the end of the line.
+: Text in a YAML file that is typically intended for humans to read, but not
+considered part of the YAML data model.
+Comment text may be discarded entirely by a parser.
+It may also be reported as events and stored in the DOM or possibly in a
+native data structure.
+Syntactically, comments are text starting with a `#` character and continuing
+to the end of the line.
 
   Comments may be used within YAML documents or before/between/after them (in
-  the YAML stream).
+the YAML stream).
 
-* Composer
+Composer
 
-  A composer is the processor in a load stack that gets events from a parser
-  and uses them to create the DOM state.
+: A composer is the processor in a load stack that gets events from a parser
+and uses them to create the DOM state.
 
-* Constructor
+Constructor
 
-  A constructor is the processor in a load stack that iterates over a DOM tree
-  and creates a native representation.
+: A constructor is the processor in a load stack that iterates over a DOM tree
+and creates a native representation.
 
 ## D
 
-* Directive
+Directive
 
-  A directive is an instruction to the parser.
-  YAML 1.2 defines 2 directives: `%YAML ...` and `%TAG ...`.
-  Directives are part of a YAML stream, but not part of YAML documents or the
-  YAML data model.
+: A directive is an instruction to the parser.
+YAML 1.2 defines 2 directives: `%YAML ...` and `%TAG ...`.
+Directives are part of a YAML stream, but not part of YAML documents or the
+YAML data model.
 
-* Document
+Document
 
-  A document is a top level YAML node.
-  Most YAML files consist of a single YAML document, although they may also
-  have zero or multiple documents.
+: A document is a top level YAML node.
+Most YAML files consist of a single YAML document, although they may also
+have zero or multiple documents.
 
-* Double quoted scalar
+Double quoted scalar
 
-  Scalar values written in the double quote style are capable of expressing any
-  possible string value.
-  The double quoted style is the only scalar style capable of that.
-  They use a number of escape sequences to represent non-printable characters.
+: Scalar values written in the double quote style are capable of expressing any
+possible string value.
+The double quoted style is the only scalar style capable of that.
+They use a number of escape sequences to represent non-printable characters.
 
-* DOM
+DOM
 
-  A DOM is an information state that is a tree of nodes created by a composer
-  or a representer and consumed by a constructor or a serializer.
-  A DOM may also be consumed directly by an application.
-  A DOM API can offer a lot more information and processing options than a
-  native data structure.
+: A DOM is an information state that is a tree of nodes created by a composer
+or a representer and consumed by a constructor or a serializer.
+A DOM may also be consumed directly by an application.
+A DOM API can offer a lot more information and processing options than a
+native data structure.
 
   Frameworks do not need to implement a DOM as part of their stacks, as long as
-  they adhere to the YAML specification rules for moving information through
-  the DOM.
+they adhere to the YAML specification rules for moving information through
+the DOM.
 
-* Dumper / Dump
+Dumper / Dump
 
-  A dumper is a processor that links all the processors of a dump stack, taking
-  information all the way from native to file states.
+: A dumper is a processor that links all the processors of a dump stack, taking
+information all the way from native to file states.
 
-* Dump Stack
+Dump Stack
 
-  The set of processors that move YAML information from a native state to a
-  file state.
+: The set of processors that move YAML information from a native state to a
+file state.
 
 ## E
 
-* Emitter / Emit
+Emitter / Emit
 
-  An emitter is the process in the dump stack that turns events into tokens.
-  In the dump stack the events come from the serializer.
-  In stream processing the events would come from an application filter process
-  that would typically be reading events from a parser.
+: An emitter is the process in the dump stack that turns events into tokens.
+In the dump stack the events come from the serializer.
+In stream processing the events would come from an application filter process
+that would typically be reading events from a parser.
 
-* Event
+Event
 
-  An event is an information state produced by a parser or serializer and
-  consumed by a composer or emitter.
-  Event types include:
+: An event is an information state produced by a parser or serializer and
+consumed by a composer or emitter.
+Event types include:
 
   * stream-start
   * stream-end
@@ -142,307 +142,307 @@ meanings.
 
 ## F
 
-* File
+File
 
-  File is the term for YAML information in a final textual state, external to
-  the YAML stack.
-  A YAML framework loads from a file and dumps to a file.
-  The term is abstract and doesn't have to be a file stored to disk.
-  It might be a socket or other external data source/target.
+: File is the term for YAML information in a final textual state, external to
+the YAML stack.
+A YAML framework loads from a file and dumps to a file.
+The term is abstract and doesn't have to be a file stored to disk.
+It might be a socket or other external data source/target.
 
-* Flow / Flow Collection Style
+Flow / Flow Collection Style
 
-  In YAML, mappings and sequences can be represented in a style that uses curly
-  braces and square brackets in the same manner that JSON does.
-  Block collections may contain any collection nodes in the flow style, but
-  flow collections may only contain collections in the flow style.
+: In YAML, mappings and sequences can be represented in a style that uses curly
+braces and square brackets in the same manner that JSON does.
+Block collections may contain any collection nodes in the flow style, but
+flow collections may only contain collections in the flow style.
 
-* Folded Scalar Style
+Folded Scalar Style
 
-  Folded scalars occur only in block collections.
-  They are indicated by a greater-than sign.
-  The indented lines that follow replace newlines with a space, and two or more
-  consecutive newlines with n-1 literal newlines.
+: Folded scalars occur only in block collections.
+They are indicated by a greater-than sign.
+The indented lines that follow replace newlines with a space, and two or more
+consecutive newlines with n-1 literal newlines.
 
-* Framework / YAML Framework
+Framework / YAML Framework
 
-  A full YAML processing implementation in a given programming language.
-  A framework almost always has at least a Loader and a Dumper.
-  A complete, full-featured YAML framework would also support things like
-  schema processors, path referencing, DOM API and standard library support,
-  among many other details.
+: A full YAML processing implementation in a given programming language.
+A framework almost always has at least a Loader and a Dumper.
+A complete, full-featured YAML framework would also support things like
+schema processors, path referencing, DOM API and standard library support,
+among many other details.
 
 ## H
 
-* Hash
+Hash
 
-  The word hash is sometimes used to refer to a native data structure typically
-  constructed from a mapping node.
+: The word hash is sometimes used to refer to a native data structure typically
+constructed from a mapping node.
 
 ## I
 
-* Information
+Information
 
-  Any of the various data bits flowing through a YAML stack.
+: Any of the various data bits flowing through a YAML stack.
 
 ## J
 
-* JSON
+JSON
 
-  When used with the JSON Schema or a derivative of that schema, YAML is a
-  syntactic and semantic superset of the JSON data format.
-  That is, a YAML loader using such a schema (which is typical) can load a JSON
-  file and produce the same result as a JSON loading (often called `parse`)
-  process.
+: When used with the JSON Schema or a derivative of that schema, YAML is a
+syntactic and semantic superset of the JSON data format.
+That is, a YAML loader using such a schema (which is typical) can load a JSON
+file and produce the same result as a JSON loading (often called `parse`)
+process.
 
 ## K
 
-* Kind
+Kind
 
-  There are 3 kinds of nodes in YAML: mappings, sequences and scalars.
-  A kind refers to the raw structure.
-  A kind should not be confused with a type.
+: There are 3 kinds of nodes in YAML: mappings, sequences and scalars.
+A kind refers to the raw structure.
+A kind should not be confused with a type.
 
 ## L
 
-* Library
+Library
 
-  The DOM resolves tags to functions.
-  These functions come from the library that is registered to the DOM; often
-  the YAML standard library.
+: The DOM resolves tags to functions.
+These functions come from the library that is registered to the DOM; often
+the YAML standard library.
 
-* List
+List
 
-  A list is a property of a type.
-  List types are often made from sequence nodes, but they can be result of any
-  tag function whose return type is a list type.
+: A list is a property of a type.
+List types are often made from sequence nodes, but they can be result of any
+tag function whose return type is a list type.
 
-* Literal / Literal Scalar Style
+Literal / Literal Scalar Style
 
-  The literal scalar is similar to the heredoc style found in some programming
-  languages like Perl and Bash.
-  No character escaping is allowed and newlines are literal.
-  Any valid YAML file's content can be encoded in the literal style by simply
-  indenting it.
+: The literal scalar is similar to the heredoc style found in some programming
+languages like Perl and Bash.
+No character escaping is allowed and newlines are literal.
+Any valid YAML file's content can be encoded in the literal style by simply
+indenting it.
 
-* Loader / Load
+Loader / Load
 
-  A dumper is a processor that links all the processors of a dump stack, taking
-  information all the way from native to file states.
+: A dumper is a processor that links all the processors of a dump stack, taking
+information all the way from native to file states.
 
-* Load Stack
+Load Stack
 
-  The set of processors that move YAML information from the file state to the
-  native state: read, lex, parse, compose, construct.
+: The set of processors that move YAML information from the file state to the
+native state: read, lex, parse, compose, construct.
 
 ## M
 
-* Mapping
+Mapping
 
-  A mapping is a kind of YAML node that consists of a set of zero or more
-  key/value pairs.
-  Any kind of node is allowed to be a key, even though native models rarely
-  support this.
-  Equivalent keys (if they can be detected) are not supported.
+: A mapping is a kind of YAML node that consists of a set of zero or more
+key/value pairs.
+Any kind of node is allowed to be a key, even though native models rarely
+support this.
+Equivalent keys (if they can be detected) are not supported.
 
-* Model / Data Model
+Model / Data Model
 
-  This word describes elementary kinds of data that YAML represents.
-  A YAML file is a stream of YAML documents each of which have one root node.
-  Nodes may be mappings, sequences or scalars.
-  Nodes may be annotated with anchors and/or tags.
-  An alias may be used for any node.
+: This word describes elementary kinds of data that YAML represents.
+A YAML file is a stream of YAML documents each of which have one root node.
+Nodes may be mappings, sequences or scalars.
+Nodes may be annotated with anchors and/or tags.
+An alias may be used for any node.
 
 ## N
 
-* Native / Native Object
+Native / Native Object
 
-  A language specific state that is the final result of a loader, or the
-  initial state given to a dumper.
-  This state is defined by the programming language being used, or maybe a form
-  crafted by the author of the application.
-  Some YAML frameworks may use the DOM state as their native state.
+: A language specific state that is the final result of a loader, or the
+initial state given to a dumper.
+This state is defined by the programming language being used, or maybe a form
+crafted by the author of the application.
+Some YAML frameworks may use the DOM state as their native state.
 
   As an example, in Python, generic native states include dictionaries, lists,
-  tuples and values.
-  Custom native states include the instance objects of Python classes.
+tuples and values.
+Custom native states include the instance objects of Python classes.
 
-* Node
+Node
 
-  A node is an addressable point in a YAML document.
-  Mappings, sequences, scalars are nodes.
-  An alias is a reference to a node.
-  Anchors and tags are annotations to nodes.
+: A node is an addressable point in a YAML document.
+Mappings, sequences, scalars are nodes.
+An alias is a reference to a node.
+Anchors and tags are annotations to nodes.
 
-* Null
+Null
 
-  Null is a native value supported by most schemas.
-  The plain value `null` as well as the plain empty value is most often used to
-  represent it.
+: Null is a native value supported by most schemas.
+The plain value `null` as well as the plain empty value is most often used to
+represent it.
 
 ## P
 
-* Parser / Parse
+Parser / Parse
 
-  A parser is the processor in the load stack that reads tokens, matches them
-  against a grammar and write events.
-  It may also throw an error if the tokens don't match the grammar.
-  The events are usually consumed by the composer to create a DOM, but they
-  might also be processed directly by a streaming application.
+: A parser is the processor in the load stack that reads tokens, matches them
+against a grammar and write events.
+It may also throw an error if the tokens don't match the grammar.
+The events are usually consumed by the composer to create a DOM, but they
+might also be processed directly by a streaming application.
 
-* Plain Scalar
+Plain Scalar
 
-  Plain refers to the quoting style of a scalar where the value is unquoted; as
-  opposed to single/double quoted or literal or folded styles.
-  A scalar-value event contains a flag as to whether the scalar was plain or
-  not.
-  Plain scalars are often assigned tags based on their content value.
+: Plain refers to the quoting style of a scalar where the value is unquoted; as
+opposed to single/double quoted or literal or folded styles.
+A scalar-value event contains a flag as to whether the scalar was plain or
+not.
+Plain scalars are often assigned tags based on their content value.
 
-* Processor
+Processor
 
-  A component in the load stack or dump stack to transforms data from one state
-  to another.
-  Load stack processors include: reader, lexer, parser, composer and
-  constructor.
-  Dump stack processors include: representer, serializer, emitter, streamer and
-  writer.
+: A component in the load stack or dump stack to transforms data from one state
+to another.
+Load stack processors include: reader, lexer, parser, composer and
+constructor.
+Dump stack processors include: representer, serializer, emitter, streamer and
+writer.
 
 ## R
 
-* Reader / Read
+Reader / Read
 
-  A reader is a processor in the load stack that reads a file and produces a
-  stream of unicode characters.
+: A reader is a processor in the load stack that reads a file and produces a
+stream of unicode characters.
 
-* Reference
+Reference
 
-  A reference can be thought of as a pointer to another node in the DOM.
-  In YAML 1.2 the only references are aliases.
+: A reference can be thought of as a pointer to another node in the DOM.
+In YAML 1.2 the only references are aliases.
 
-* Representer / Represent
+Representer / Represent
 
-  A representer is a process that turns native programming data into a YAML DOM
-  state.
+: A representer is a process that turns native programming data into a YAML DOM
+state.
 
 ## S
 
-* Scalar
+Scalar
 
-  A scalar is a a leaf node that contains exactly one value.
-  Strings, numbers and booean values are examples of scalars.
+: A scalar is a a leaf node that contains exactly one value.
+Strings, numbers and booean values are examples of scalars.
 
-* Schema
+Schema
 
-  Schema in YAML refers to all the external information required to process a
-  YAML stream.
-  Unlike traditional schemas which typically enforce the structural typing of
-  information, a YAML schema can alter the semantic meaning of a YAML file.
+: Schema in YAML refers to all the external information required to process a
+YAML stream.
+Unlike traditional schemas which typically enforce the structural typing of
+information, a YAML schema can alter the semantic meaning of a YAML file.
 
   In YAML 1.2, schemas are almost always expressed in the source code of the
-  framework.
-  In future versions, a YAML Schema language can be used to control the
-  behavior of a framework (if the framework supports it).
+framework.
+In future versions, a YAML Schema language can be used to control the
+behavior of a framework (if the framework supports it).
 
-* Sequence
+Sequence
 
-  A sequence is a collection node that consists of zero or more nodes.
+: A sequence is a collection node that consists of zero or more nodes.
 
-* Serializer / Serialize
+Serializer / Serialize
 
-  A serializer is the process in the dump stack that iterates over the DOM and
-  produces events that are typically sent to an emitter.
+: A serializer is the process in the dump stack that iterates over the DOM and
+produces events that are typically sent to an emitter.
 
-* Single quoted scalar
+Single quoted scalar
 
-  Scalar values written in the single quote style can contain any sequence of
-  printable characters except the single quote itself.
-  The single quotes must be escaped using two single quotes (`''`).
+: Scalar values written in the single quote style can contain any sequence of
+printable characters except the single quote itself.
+The single quotes must be escaped using two single quotes (`''`).
 
-* Stack / YAML Stack
+Stack / YAML Stack
 
-  YAML processing occurs as 2 stacks of processors, each moving data (in
-  opposite directions) between YAML formatted text and computer memory states.
-  They are called the load stack and the dump stack.
-  Collectively the 2 stacks may be referred to as "the YAML stack".
+: YAML processing occurs as 2 stacks of processors, each moving data (in
+opposite directions) between YAML formatted text and computer memory states.
+They are called the load stack and the dump stack.
+Collectively the 2 stacks may be referred to as "the YAML stack".
 
-* Standard Library
+Standard Library
 
-  Versions of YAML after 1.2 define a standard library of tag functions.
+: Versions of YAML after 1.2 define a standard library of tag functions.
 
-* State
+State
 
-  A form that YAML information is in during various stages of the stack.
-  States include: files, characters, tokens, events, DOMs and native objects.
-  For instance an "event" is a data state produced by a parser or a serializer,
-  and consumed by a composer or an emitter.
+: A form that YAML information is in during various stages of the stack.
+States include: files, characters, tokens, events, DOMs and native objects.
+For instance an "event" is a data state produced by a parser or a serializer,
+and consumed by a composer or an emitter.
 
-* Stream (Character Stream)
+Stream (Character Stream)
 
-  The set of unicode characters produced by a reader or streamer and consumed
-  by a lexer or writer.
+: The set of unicode characters produced by a reader or streamer and consumed
+by a lexer or writer.
 
-* Stream (YAML Stream or Document Stream)
+Stream (YAML Stream or Document Stream)
 
-  A YAML file is considered a "stream" of zero or more documents.
-  A stream may also have directives and/or comments before, between or after
-  the documents.
-  This is the typical meaning when the word "stream" is used with no qualifier.
+: A YAML file is considered a "stream" of zero or more documents.
+A stream may also have directives and/or comments before, between or after
+the documents.
+This is the typical meaning when the word "stream" is used with no qualifier.
 
-* Streamer
+Streamer
 
-  This is the dump stack sister process to the lexer.
-  It simply joins tokens into a character stream.
+: This is the dump stack sister process to the lexer.
+It simply joins tokens into a character stream.
 
-* String
+String
 
-  String is a heavily overloaded term in YAML and depends on the context in
-  which it is used.
+: String is a heavily overloaded term in YAML and depends on the context in
+which it is used.
 
-* Style
+Style
 
-  YAML has multiple styles to represent collections and scalars.
-  Collection styles are "block" and "flow".
-  Scalar styles are "plain", "single quoted", "double quoted", "literal" and
-  "folded".
+: YAML has multiple styles to represent collections and scalars.
+Collection styles are "block" and "flow".
+Scalar styles are "plain", "single quoted", "double quoted", "literal" and
+"folded".
 
 ## T
 
-* Tag
+Tag
 
-  A tag is an annotation on a node.
-  Tags are identifers preceded by a `!`, like `!foo` or `!!str`.
-  A tag identifier is used to identify a function that will be applied to a
-  node when it is retrieved from the DOM.
-  The function's return type is can be considered the "type" of the node.
+: A tag is an annotation on a node.
+Tags are identifers preceded by a `!`, like `!foo` or `!!str`.
+A tag identifier is used to identify a function that will be applied to a
+node when it is retrieved from the DOM.
+The function's return type is can be considered the "type" of the node.
 
   While tags may be written explicitly into a YAML file using the `!abc`
-  syntax, it is quite common for tags to be added to nodes implicitly according
-  to the rules of a schema.
+syntax, it is quite common for tags to be added to nodes implicitly according
+to the rules of a schema.
 
-* Token
+Token
 
-  A token is a piece of information that is produced by a lexer or emitter.
-  A token has a name and a value.
-  The value is a sequence of zero or more contiguous characters from (or for) a
-  character stream.
+: A token is a piece of information that is produced by a lexer or emitter.
+A token has a name and a value.
+The value is a sequence of zero or more contiguous characters from (or for) a
+character stream.
 
-* Type
+Type
 
-  A type is a set of constraints on a node.
-  Types are defined by schemas.
+: A type is a set of constraints on a node.
+Types are defined by schemas.
 
 ## W
 
-* Writer / Write
+Writer / Write
 
-  A writer is the processor in a dump stack that encodes unicode characters and
-  writes them to a file state.
+: A writer is the processor in a dump stack that encodes unicode characters and
+writes them to a file state.
 
 ## Y
 
-* YAML
+YAML
 
-  YAML is a programming-language-agnostic data serialization language.
-  "YAML" rhymes with "camel".
-  YAML is a recursive backronym that stands for "YAML Ain't Markup Language".
-  People often think YAML is Yet Another Markup Language, but it Ain't!
+: YAML is a programming-language-agnostic data serialization language.
+"YAML" rhymes with "camel".
+YAML is a recursive backronym that stands for "YAML Ain't Markup Language".
+People often think YAML is Yet Another Markup Language, but it Ain't!

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,7 +1,7 @@
 YAML Developer Documentation
 ============================
 
-The following documentation pages are important for the devlopers of
-YAML frameworks to understand.
+The following documentation pages are important for the developers of YAML
+frameworks to understand.
 
 * [YAML Vocabulary Glossary](glossary)

--- a/rfc/ReadMe.md
+++ b/rfc/ReadMe.md
@@ -10,8 +10,8 @@ this directory.
 
 ## RFC Process
 
-RFCs start out as GitHub Pull Requests (PRs) and should be based on the
-[RFC Template](RFC-0000-template.md) file.
+RFCs start out as GitHub Pull Requests (PRs) and should be based on the [RFC
+Template](RFC-0000-template.md) file.
 Each PR is reviewed by the core team to make sure it is something that should
 be under consideration/discussion.
 

--- a/spec/1.2.2/ext/glossary.md
+++ b/spec/1.2.2/ext/glossary.md
@@ -1,1 +1,446 @@
-../../../doc/glossary.md
+YAML Vocabulary Glossary
+========================
+
+The YAML data language and its specification has its own vocabulary.
+It is important to use the correct terms when developers discuss YAML topics.
+For example the terms: `list`, `array` and `sequence` seem like they are the
+same thing and can be used interchangably, but in YAML they have different
+meanings.
+
+## A
+
+Alias
+:
+An alias is a reference to another YAML node.
+It similar to a pointer in the C programming language.
+The alias `*foo` is a reference to a node with an anchor `&foo`.
+
+Anchor
+:
+An anchor is a label attached to a node.
+The node can be used elsewhere by referencing it with an alias.
+A node with the anchor `&foo` can be referenced elsewhere with the alias
+`*foo`.
+
+Application
+:
+An end user program using a YAML framework.
+
+Array
+:
+The word array is sometimes used to refer to a native data structure typically
+constructed from a sequence node.
+
+## B
+
+Block / Block Collection Style
+:
+Block collections are written in the indentation-based scoping style that YAML
+is most known for.
+
+Boolean
+:
+Boolean is a native state consisting of the values true and false.
+Most constructors/schemas support booleans.
+It is typical for a schema to use the plain scalars `true` and `false` to
+assign the boolean tag function.
+
+## C
+
+Comment
+:
+Text in a YAML file that is typically intended for humans to read, but not
+considered part of the YAML data model.
+Comment text may be discarded entirely by a parser.
+It may also be reported as events and stored in the DOM or possibly in a native
+data structure.
+Syntactically, comments are text starting with a `#` character and continuing
+to the end of the line.
+:
+Comments may be used within YAML documents or before/between/after them (in the
+YAML stream).
+
+Composer
+:
+A composer is the processor in a load stack that gets events from a parser and
+uses them to create the DOM state.
+
+Constructor
+:
+A constructor is the processor in a load stack that iterates over a DOM tree
+and creates a native representation.
+
+## D
+
+Directive
+:
+A directive is an instruction to the parser.
+YAML 1.2 defines 2 directives: `%YAML ...` and `%TAG ...`.
+Directives are part of a YAML stream, but not part of YAML documents or the
+YAML data model.
+
+Document
+:
+A document is a top level YAML node.
+Most YAML files consist of a single YAML document, although they may also have
+zero or multiple documents.
+
+Double quoted scalar
+:
+Scalar values written in the double quote style are capable of expressing any
+possible string value.
+The double quoted style is the only scalar style capable of that.
+They use a number of escape sequences to represent non-printable characters.
+
+DOM
+:
+A DOM is an information state that is a tree of nodes created by a composer or
+a representer and consumed by a constructor or a serializer.
+A DOM may also be consumed directly by an application.
+A DOM API can offer a lot more information and processing options than a native
+data structure.
+:
+Frameworks do not need to implement a DOM as part of their stacks, as long as
+they adhere to the YAML specification rules for moving information through the
+DOM.
+
+Dumper / Dump
+:
+A dumper is a processor that links all the processors of a dump stack, taking
+information all the way from native to file states.
+
+Dump Stack
+:
+The set of processors that move YAML information from a native state to a file
+state.
+
+## E
+
+Emitter / Emit
+:
+An emitter is the process in the dump stack that turns events into tokens.
+In the dump stack the events come from the serializer.
+In stream processing the events would come from an application filter process
+that would typically be reading events from a parser.
+
+Event
+:
+An event is an information state produced by a parser or serializer and
+consumed by a composer or emitter.
+Event types include:
+:
+* stream-start
+* stream-end
+* document-start
+* document-end
+* mapping-start
+* mapping-end
+* sequence-start
+* sequence-end
+* scalar-value
+* alias-name
+
+## F
+
+File
+:
+File is the term for YAML information in a final textual state, external to the
+YAML stack.
+A YAML framework loads from a file and dumps to a file.
+The term is abstract and doesn't have to be a file stored to disk.
+It might be a socket or other external data source/target.
+
+Flow / Flow Collection Style
+:
+In YAML, mappings and sequences can be represented in a style that uses curly
+braces and square brackets in the same manner that JSON does.
+Block collections may contain any collection nodes in the flow style, but flow
+collections may only contain collections in the flow style.
+
+Folded Scalar Style
+:
+Folded scalars occur only in block collections.
+They are indicated by a greater-than sign.
+The indented lines that follow replace newlines with a space, and two or more
+consecutive newlines with n-1 literal newlines.
+
+Framework / YAML Framework
+:
+A full YAML processing implementation in a given programming language.
+A framework almost always has at least a Loader and a Dumper.
+A complete, full-featured YAML framework would also support things like schema
+processors, path referencing, DOM API and standard library support, among many
+other details.
+
+## H
+
+Hash
+:
+The word hash is sometimes used to refer to a native data structure typically
+constructed from a mapping node.
+
+## I
+
+Information
+:
+Any of the various data bits flowing through a YAML stack.
+
+## J
+
+JSON
+:
+When used with the JSON Schema or a derivative of that schema, YAML is a
+syntactic and semantic superset of the JSON data format.
+That is, a YAML loader using such a schema (which is typical) can load a JSON
+file and produce the same result as a JSON loading (often called `parse`)
+process.
+
+## K
+
+Kind
+:
+There are 3 kinds of nodes in YAML: mappings, sequences and scalars.
+A kind refers to the raw structure.
+A kind should not be confused with a type.
+
+## L
+
+Library
+:
+The DOM resolves tags to functions.
+These functions come from the library that is registered to the DOM; often the
+YAML standard library.
+
+List
+:
+A list is a property of a type.
+List types are often made from sequence nodes, but they can be result of any
+tag function whose return type is a list type.
+
+Literal / Literal Scalar Style
+:
+The literal scalar is similar to the heredoc style found in some programming
+languages like Perl and Bash.
+No character escaping is allowed and newlines are literal.
+Any valid YAML file's content can be encoded in the literal style by simply
+indenting it.
+
+Loader / Load
+:
+A dumper is a processor that links all the processors of a dump stack, taking
+information all the way from native to file states.
+
+Load Stack
+:
+The set of processors that move YAML information from the file state to the
+native state: read, lex, parse, compose, construct.
+
+## M
+
+Mapping
+:
+A mapping is a kind of YAML node that consists of a set of zero or more
+key/value pairs.
+Any kind of node is allowed to be a key, even though native models rarely
+support this.
+Equivalent keys (if they can be detected) are not supported.
+
+Model / Data Model
+:
+This word describes elementary kinds of data that YAML represents.
+A YAML file is a stream of YAML documents each of which have one root node.
+Nodes may be mappings, sequences or scalars.
+Nodes may be annotated with anchors and/or tags.
+An alias may be used for any node.
+
+## N
+
+Native / Native Object
+:
+A language specific state that is the final result of a loader, or the initial
+state given to a dumper.
+This state is defined by the programming language being used, or maybe a form
+crafted by the author of the application.
+Some YAML frameworks may use the DOM state as their native state.
+:
+As an example, in Python, generic native states include dictionaries, lists,
+tuples and values.
+Custom native states include the instance objects of Python classes.
+
+Node
+:
+A node is an addressable point in a YAML document.
+Mappings, sequences, scalars are nodes.
+An alias is a reference to a node.
+Anchors and tags are annotations to nodes.
+
+Null
+:
+Null is a native value supported by most schemas.
+The plain value `null` as well as the plain empty value is most often used to
+represent it.
+
+## P
+
+Parser / Parse
+:
+A parser is the processor in the load stack that reads tokens, matches them
+against a grammar and write events.
+It may also throw an error if the tokens don't match the grammar.
+The events are usually consumed by the composer to create a DOM, but they might
+also be processed directly by a streaming application.
+
+Plain Scalar
+:
+Plain refers to the quoting style of a scalar where the value is unquoted; as
+opposed to single/double quoted or literal or folded styles.
+A scalar-value event contains a flag as to whether the scalar was plain or not.
+Plain scalars are often assigned tags based on their content value.
+
+Processor
+:
+A component in the load stack or dump stack to transforms data from one state
+to another.
+Load stack processors include: reader, lexer, parser, composer and constructor.
+Dump stack processors include: representer, serializer, emitter, streamer and
+writer.
+
+## R
+
+Reader / Read
+:
+A reader is a processor in the load stack that reads a file and produces a
+stream of unicode characters.
+
+Reference
+:
+A reference can be thought of as a pointer to another node in the DOM.
+In YAML 1.2 the only references are aliases.
+
+Representer / Represent
+:
+A representer is a process that turns native programming data into a YAML DOM
+state.
+
+## S
+
+Scalar
+:
+A scalar is a a leaf node that contains exactly one value.
+Strings, numbers and booean values are examples of scalars.
+
+Schema
+:
+Schema in YAML refers to all the external information required to process a
+YAML stream.
+Unlike traditional schemas which typically enforce the structural typing of
+information, a YAML schema can alter the semantic meaning of a YAML file.
+:
+In YAML 1.2, schemas are almost always expressed in the source code of the
+framework.
+In future versions, a YAML Schema language can be used to control the behavior
+of a framework (if the framework supports it).
+
+Sequence
+:
+A sequence is a collection node that consists of zero or more nodes.
+
+Serializer / Serialize
+:
+A serializer is the process in the dump stack that iterates over the DOM and
+produces events that are typically sent to an emitter.
+
+Single quoted scalar
+:
+Scalar values written in the single quote style can contain any sequence of
+printable characters except the single quote itself.
+The single quotes must be escaped using two single quotes (`''`).
+
+Stack / YAML Stack
+:
+YAML processing occurs as 2 stacks of processors, each moving data (in opposite
+directions) between YAML formatted text and computer memory states.
+They are called the load stack and the dump stack.
+Collectively the 2 stacks may be referred to as "the YAML stack".
+
+Standard Library
+:
+Versions of YAML after 1.2 define a standard library of tag functions.
+
+State
+:
+A form that YAML information is in during various stages of the stack.
+States include: files, characters, tokens, events, DOMs and native objects.
+For instance an "event" is a data state produced by a parser or a serializer,
+and consumed by a composer or an emitter.
+
+Stream (Character Stream)
+:
+The set of unicode characters produced by a reader or streamer and consumed by
+a lexer or writer.
+
+Stream (YAML Stream or Document Stream)
+:
+A YAML file is considered a "stream" of zero or more documents.
+A stream may also have directives and/or comments before, between or after the
+documents.
+This is the typical meaning when the word "stream" is used with no qualifier.
+
+Streamer
+:
+This is the dump stack sister process to the lexer.
+It simply joins tokens into a character stream.
+
+String
+:
+String is a heavily overloaded term in YAML and depends on the context in which
+it is used.
+
+Style
+:
+YAML has multiple styles to represent collections and scalars.
+Collection styles are "block" and "flow".
+Scalar styles are "plain", "single quoted", "double quoted", "literal" and
+"folded".
+
+## T
+
+Tag
+:
+A tag is an annotation on a node.
+Tags are identifers preceded by a `!`, like `!foo` or `!!str`.
+A tag identifier is used to identify a function that will be applied to a node
+when it is retrieved from the DOM.
+The function's return type is can be considered the "type" of the node.
+:
+While tags may be written explicitly into a YAML file using the `!abc` syntax,
+it is quite common for tags to be added to nodes implicitly according to the
+rules of a schema.
+
+Token
+:
+A token is a piece of information that is produced by a lexer or emitter.
+A token has a name and a value.
+The value is a sequence of zero or more contiguous characters from (or for) a
+character stream.
+
+Type
+:
+A type is a set of constraints on a node.
+Types are defined by schemas.
+
+## W
+
+Writer / Write
+:
+A writer is the processor in a dump stack that encodes unicode characters and
+writes them to a file state.
+
+## Y
+
+YAML
+:
+YAML is a programming-language-agnostic data serialization language.
+"YAML" rhymes with "camel".
+YAML is a recursive backronym that stands for "YAML Ain't Markup Language".
+People often think YAML is Yet Another Markup Language, but it Ain't!

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -2707,16 +2707,16 @@ Folding does distinguish between these cases in the following way:
 
 Block Folding
 :
-In the [folded block style], the final [line break] and trailing [empty
-lines] are subject to [chomping] and are never folded.
+In the [folded block style], the final [line break] and trailing [empty lines]
+are subject to [chomping] and are never folded.
 In addition, folding does not apply to [line breaks] surrounding text lines
 that contain leading [white space].
 Note that such a [more-indented] line may consist only of such leading [white
 space].
 :
-The combined effect of the _block line folding_ rules is that each
-"paragraph" is interpreted as a line, [empty lines] are interpreted as a line
-feed and the formatting of [more-indented] lines is preserved.
+The combined effect of the _block line folding_ rules is that each "paragraph"
+is interpreted as a line, [empty lines] are interpreted as a line feed and the
+formatting of [more-indented] lines is preserved.
 
 
 **Example #. Block Folding**
@@ -3321,8 +3321,8 @@ semantics to the same [local tag].
 
 Global Tag Prefix
 :
-If the prefix begins with a character other than "`!`", it must be a valid
-URI prefix, and should contain at least the scheme.
+If the prefix begins with a character other than "`!`", it must be a valid URI
+prefix, and should contain at least the scheme.
 [Shorthands] using the associated [handle] are expanded to globally unique URI
 tags and their semantics is consistent across [applications].
 In particular, every [document] in every [stream] must assign the same
@@ -3538,8 +3538,8 @@ ERROR:
 
 Non-Specific Tags
 :
-If a [node] has no tag property, it is assigned a [non-specific tag] that
-needs to be [resolved] to a [specific] one.
+If a [node] has no tag property, it is assigned a [non-specific tag] that needs
+to be [resolved] to a [specific] one.
 This [non-specific tag] is "`!`" for non-[plain scalars] and "`?`" for all
 other [nodes].
 This is the only case where the [node style] has any effect on the [content]
@@ -6493,8 +6493,8 @@ Definition
 Scalars of this type should be [bound] to a [native] integer data type, if
 possible.
 :
-Some languages (such as Perl) provide only a "number" type that allows for
-both integer and floating-point values.
+Some languages (such as Perl) provide only a "number" type that allows for both
+integer and floating-point values.
 A YAML [processor] may use such a type for integers as long as they round-trip
 properly.
 :
@@ -6538,13 +6538,12 @@ Definition
 [Represents] an approximation to real numbers, including three special values
 (positive and negative infinity and "not a number").
 :
-Some languages (such as Perl) provide only a "number" type that allows for
-both integer and floating-point values.
+Some languages (such as Perl) provide only a "number" type that allows for both
+integer and floating-point values.
 A YAML [processor] may use such a type for floating-point numbers, as long as
 they round-trip properly.
 :
-Not all floating-point values can be stored exactly in any given [native]
-type.
+Not all floating-point values can be stored exactly in any given [native] type.
 Hence a float value may change by "a small amount" when round-tripped.
 The supported range and accuracy depends on the implementation, though 32 bit
 IEEE floats should be safe.
@@ -6554,8 +6553,8 @@ Since YAML does not specify a particular accuracy, using floating-point
 
 Canonical Form
 :
-Either `0`, `.inf`, `-.inf`, `.nan` or scientific notation matching the
-regular expression  
+Either `0`, `.inf`, `-.inf`, `.nan` or scientific notation matching the regular
+expression  
 `-? [1-9] ( \. [0-9]* [1-9] )? ( e [-+] [1-9] [0-9]* )?`.
 
 

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -981,10 +981,10 @@ scheme.
 [Tags] in a YAML stream must therefore be [presented] in a canonical way so
 that such comparison would yield the correct results.
 
-> If a node has itself as a descendant (via an alias), then determining the
+  If a node has itself as a descendant (via an alias), then determining the
 equality of that node is implementation-defined.
 
-: A YAML [processor] may treat equal [scalars] as if they were identical.
+  A YAML [processor] may treat equal [scalars] as if they were identical.
 
 
 ? Uniqueness

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -724,20 +724,20 @@ _Dumping_ native data structures to a character [stream] is done using the
 following three stages:
 
 
-? Representing Native Data Structures
-
-: YAML _represents_ any _native data structure_ using three [node kinds]:
+Representing Native Data Structures
+:
+YAML _represents_ any _native data structure_ using three [node kinds]:
 [sequence] - an ordered series of entries; [mapping] - an unordered association
 of [unique] [keys] to [values]; and [scalar] - any datum with opaque structure
 presentable as a series of Unicode characters.
-
-: Combined, these primitives generate directed graph structures.
+:
+Combined, these primitives generate directed graph structures.
 These primitives were chosen because they are both powerful and familiar: the
 [sequence] corresponds to a Perl array and a Python list, the [mapping]
 corresponds to a Perl hash table and a Python dictionary.
 The [scalar] represents strings, integers, dates and other atomic data types.
-
-: Each YAML [node] requires, in addition to its [kind] and [content], a [tag]
+:
+Each YAML [node] requires, in addition to its [kind] and [content], a [tag]
 specifying its data type.
 Type specifiers are either [global] URIs or are [local] in scope to a single
 [application].
@@ -749,9 +749,9 @@ This simple model can represent any data structure independent of programming
 language.
 
 
-? Serializing the Representation Graph
-
-: For sequential access mediums, such as an event callback API, a YAML
+Serializing the Representation Graph
+:
+For sequential access mediums, such as an event callback API, a YAML
 [representation] must be _serialized_ to an ordered tree.
 Since in a YAML [representation], [mapping keys] are unordered and [nodes] may
 be referenced more than once (have more than one incoming "arrow"), the
@@ -765,9 +765,9 @@ The result of this process, a YAML [serialization tree], can then be traversed
 to produce a series of event calls for one-pass processing of YAML data.
 
 
-? Presenting the Serialization Tree
-
-: The final output process is _presenting_ the YAML [serializations] as a
+Presenting the Serialization Tree
+:
+The final output process is _presenting_ the YAML [serializations] as a
 character [stream] in a human-friendly manner.
 To maximize human readability, YAML offers a rich set of stylistic options
 which go far beyond the minimal functional needs of simple data storage.
@@ -786,27 +786,26 @@ _Loading_ [native data structures] from a character [stream] is done using the
 following three stages:
 
 
-? Parsing the Presentation Stream
-
-: _Parsing_ is the inverse process of [presentation], it takes a [stream] of
+Parsing the Presentation Stream
+:
+_Parsing_ is the inverse process of [presentation], it takes a [stream] of
 characters and produces a [serialization tree].
 Parsing discards all the [details] introduced in the [presentation] process,
 reporting only the [serialization tree].
 Parsing can fail due to [ill-formed] input.
 
 
-? Composing the Representation Graph
-
-: _Composing_ takes a [serialization tree] and produces a [representation
-graph].
+Composing the Representation Graph
+:
+_Composing_ takes a [serialization tree] and produces a [representation graph].
 Composing discards all the [details] introduced in the [serialization] process,
 producing only the [representation graph].
 Composing can fail due to any of several reasons, detailed [below].
 
 
-? Constructing Native Data Structures
-
-: The final input process is _constructing_ [native data structures] from the
+Constructing Native Data Structures
+:
+The final input process is _constructing_ [native data structures] from the
 YAML [representation].
 Construction must be based only on the information available in the
 [representation] and not on additional [serialization] or [presentation
@@ -877,22 +876,22 @@ In addition, each node has a [tag] which serves to restrict the set of possible
 values the content can have.
 
 
-? Scalar
+Scalar
+:
+The content of a _scalar_ node is an opaque datum that can be [presented] as a
+series of zero or more Unicode characters.
 
-: The content of a _scalar_ node is an opaque datum that can be [presented] as
-a series of zero or more Unicode characters.
 
-
-? Sequence
-
-: The content of a _sequence_ node is an ordered series of zero or more nodes.
+Sequence
+:
+The content of a _sequence_ node is an ordered series of zero or more nodes.
 In particular, a sequence may contain the same node more than once.
 It could even contain itself.
 
 
-? Mapping
-
-: The content of a _mapping_ node is an unordered set of _key/value_ node
+Mapping
+:
+The content of a _mapping_ node is an unordered set of _key/value_ node
 _pairs_, with the restriction that each of the keys is [unique].
 YAML places no further restrictions on the nodes.
 In particular, keys may be arbitrary nodes, the same node may be used as the
@@ -947,31 +946,34 @@ If both notations are used as [keys] in the same [mapping], only a YAML
 duplicate [key] as an error.
 
 
-? Canonical Form
-
-: YAML supports the need for [scalar] equality by requiring that every [scalar]
+Canonical Form
+:
+YAML supports the need for [scalar] equality by requiring that every [scalar]
 [tag] must specify a mechanism for producing the _canonical form_ of any
 [formatted content].
 This form is a Unicode character string which also [presents] the same
 [content] and can be used for equality testing.
 
 
-? Equality
-
-: Two [nodes] must have the same [tag] and [content] to be _equal_.
+Equality
+:
+Two [nodes] must have the same [tag] and [content] to be _equal_.
 Since each [tag] applies to exactly one [kind], this implies that the two
 [nodes] must have the same [kind] to be equal.
+:
 Two [scalars] are equal only when their [tags] and canonical forms are equal
 character-by-character.
 Equality of [collections] is defined recursively.
+:
 Two [sequences] are equal only when they have the same [tag] and length and
 each [node] in one [sequence] is equal to the corresponding [node] in the other
 [sequence].
+:
 Two [mappings] are equal only when they have the same [tag] and an equal set of
 [keys] and each [key] in this set is associated with equal [values] in both
 [mappings].
-
-: Different URI schemes may define different rules for testing the equality of
+:
+Different URI schemes may define different rules for testing the equality of
 URIs.
 Since a YAML [processor] cannot be reasonably expected to be aware of them all,
 it must resort to a simple character-by-character comparison of [tags] to
@@ -980,16 +982,16 @@ This also happens to be the comparison method defined by the "`tag:`" URI
 scheme.
 [Tags] in a YAML stream must therefore be [presented] in a canonical way so
 that such comparison would yield the correct results.
-
-  If a node has itself as a descendant (via an alias), then determining the
+:
+If a node has itself as a descendant (via an alias), then determining the
 equality of that node is implementation-defined.
+:
+A YAML [processor] may treat equal [scalars] as if they were identical.
 
-  A YAML [processor] may treat equal [scalars] as if they were identical.
 
-
-? Uniqueness
-
-: A [mapping's] [keys] are _unique_ if no two keys are equal to each other.
+Uniqueness
+:
+A [mapping's] [keys] are _unique_ if no two keys are equal to each other.
 Obviously, identical nodes are always considered equal.
 
 
@@ -1357,20 +1359,20 @@ production-a(1) ::=
 
 The parameters are as follows:
 
-? Indentation: `n` or `m`
+Indentation: `n` or `m`
+:
+May be any natural number, including zero. `n` may also be -1.
 
-: May be any natural number, including zero. `n` may also be -1.
 
-
-? Context: `c`
-
-: This parameter allows productions to tweak their behavior according to their
+Context: `c`
+:
+This parameter allows productions to tweak their behavior according to their
 surrounding.
 YAML supports two groups of _contexts_, distinguishing between [block styles]
 and [flow styles].
-
-: May be any of the following values:
-
+:
+May be any of the following values:
+:
 * `BLOCK-IN` -- inside block context
 * `BLOCK-OUT` -- outside block context
 * `BLOCK-KEY` -- inside block key context
@@ -1379,9 +1381,9 @@ and [flow styles].
 * `FLOW-KEY` -- inside flow key context
 
 
-? (Block) Chomping: `t`
-
-: The [line break] chomping behavior for flow scalars.
+(Block) Chomping: `t`
+:
+The [line break] chomping behavior for flow scalars.
 May be any of the following values:
 
 * `STRIP` -- remove all trailing newlines
@@ -1396,42 +1398,42 @@ prefix-style naming convention.
 Each production is given a prefix based on the type of characters it begins and
 ends with.
 
-? `e-`
+`e-`
+:
+A production matching no characters.
 
-: A production matching no characters.
+`c-`
+:
+A production starting and ending with a special character.
 
-? `c-`
+`b-`
+:
+A production matching a single [line break].
 
-: A production starting and ending with a special character.
+`nb-`
+:
+A production starting and ending with a non-[break] character.
 
-? `b-`
+`s-`
+:
+A production starting and ending with a [white space] character.
 
-: A production matching a single [line break].
+`ns-`
+:
+A production starting and ending with a non-[space] character.
 
-? `nb-`
+`l-`
+:
+A production matching complete line(s).
 
-: A production starting and ending with a non-[break] character.
+`X-Y-`
+:
+A production starting with an `X-` character and ending with a `Y-` character,
+where `X-` and `Y-` are any of the above prefixes.
 
-? `s-`
-
-: A production starting and ending with a [white space] character.
-
-? `ns-`
-
-: A production starting and ending with a non-[space] character.
-
-? `l-`
-
-: A production matching complete line(s).
-
-? `X-Y-`
-
-: A production starting with an `X-` character and ending with a `Y-`
-character, where `X-` and `Y-` are any of the above prefixes.
-
-? `X+`, `X-Y+`
-
-: A production as above, with the additional property that the matched content
+`X+`, `X-Y+`
+:
+A production as above, with the additional property that the matched content
 [indentation] level is greater than the specified `n` parameter.
 
 
@@ -2703,16 +2705,16 @@ flow styles].
 Folding does distinguish between these cases in the following way:
 
 
-? Block Folding
-
-: In the [folded block style], the final [line break] and trailing [empty
+Block Folding
+:
+In the [folded block style], the final [line break] and trailing [empty
 lines] are subject to [chomping] and are never folded.
 In addition, folding does not apply to [line breaks] surrounding text lines
 that contain leading [white space].
 Note that such a [more-indented] line may consist only of such leading [white
 space].
-
-: The combined effect of the _block line folding_ rules is that each
+:
+The combined effect of the _block line folding_ rules is that each
 "paragraph" is interpreted as a line, [empty lines] are interpreted as a line
 feed and the formatting of [more-indented] lines is preserved.
 
@@ -2738,17 +2740,17 @@ feed and the formatting of [more-indented] lines is preserved.
 * Content spaces <!-- 2:6 4:3,2 -->
 
 
-? Flow Folding
-
-: Folding in [flow styles] provides more relaxed semantics.
+Flow Folding
+:
+Folding in [flow styles] provides more relaxed semantics.
 [Flow styles] typically depend on explicit [indicators] rather than
 [indentation] to convey structure.
 Hence spaces preceding or following the text in a line are a [presentation
 detail] and must not be used to convey [content] information.
 Once all such spaces have been discarded, all [line breaks] are folded without
 exception.
-
-: The combined effect of the _flow line folding_ rules is that each "paragraph"
+:
+The combined effect of the _flow line folding_ rules is that each "paragraph"
 is interpreted as a line, [empty lines] are interpreted as line feeds and text
 can be freely [more-indented] without affecting the [content] information.
 
@@ -3163,16 +3165,16 @@ There are three tag handle variants:
 ```
 
 
-? Primary Handle
-
-: The _primary tag handle_ is a single _"`!`"_ character.
+Primary Handle
+:
+The _primary tag handle_ is a single _"`!`"_ character.
 This allows using the most compact possible notation for a single "primary"
 name space.
 By default, the prefix associated with this handle is "`!`".
 Thus, by default, [shorthands] using this handle are interpreted as [local
 tags].
-
-: It is possible to override the default behavior by providing an explicit
+:
+It is possible to override the default behavior by providing an explicit
 "`TAG`" directive, associating a different prefix for this handle.
 This provides smooth migration from using [local tags] to using [global tags]
 by the simple addition of a single "`TAG`" directive.
@@ -3204,13 +3206,13 @@ by the simple addition of a single "`TAG`" directive.
 * [c-primary-tag-handle] <!-- ! -->
 
 
-? Secondary Handle
-
-: The _secondary tag handle_ is written as _"`!!`"_.
+Secondary Handle
+:
+The _secondary tag handle_ is written as _"`!!`"_.
 This allows using a compact notation for a single "secondary" name space.
 By default, the prefix associated with this handle is "`tag:yaml.org,2002:`".
-
-: It is possible to override this default behavior by providing an explicit
+:
+It is possible to override this default behavior by providing an explicit
 "`TAG`" directive associating a different prefix for this handle.
 
 ```
@@ -3234,13 +3236,13 @@ By default, the prefix associated with this handle is "`tag:yaml.org,2002:`".
 * [c-secondary-tag-handle] <!-- !! -->
 
 
-? Named Handles
-
-: A _named tag handle_ surrounds a non-empty name with _"`!`"_ characters.
+Named Handles
+:
+A _named tag handle_ surrounds a non-empty name with _"`!`"_ characters.
 A handle name must not be used in a [tag shorthand] unless an explicit "`TAG`"
 directive has associated some prefix with it.
-
-: The name of the handle is a [presentation detail] and must not be used to
+:
+The name of the handle is a [presentation detail] and must not be used to
 convey [content] information.
 In particular, the YAML [processor] need not preserve the handle name once
 [parsing] is completed.
@@ -3279,9 +3281,9 @@ There are two _tag prefix_ variants:
 ```
 
 
-? Local Tag Prefix
-
-: If the prefix begins with a "`!`" character, [shorthands] using the [handle]
+Local Tag Prefix
+:
+If the prefix begins with a "`!`" character, [shorthands] using the [handle]
 are expanded to a [local tag].
 Note that such a [tag] is intentionally not a valid URI and its semantics are
 specific to the [application].
@@ -3317,9 +3319,9 @@ semantics to the same [local tag].
 * [c-ns-local-tag-prefix] <!-- !my- -->
 
 
-? Global Tag Prefix
-
-: If the prefix begins with a character other than "`!`", it must be a valid
+Global Tag Prefix
+:
+If the prefix begins with a character other than "`!`", it must be a valid
 URI prefix, and should contain at least the scheme.
 [Shorthands] using the associated [handle] are expanded to globally unique URI
 tags and their semantics is consistent across [applications].
@@ -3408,9 +3410,9 @@ A tag is denoted by the _"`!`" indicator_.
 ```
 
 
-? Verbatim Tags
-
-: A tag may be written _verbatim_ by surrounding it with the _"`<`" and "`>`"_
+Verbatim Tags
+:
+A tag may be written _verbatim_ by surrounding it with the _"`<`" and "`>`"_
 characters.
 In this case, the YAML [processor] must deliver the verbatim tag as-is to the
 [application].
@@ -3462,21 +3464,21 @@ ERROR:
 <!-- 4:7,3 -->
 
 
-? Tag Shorthands
-
-: A _tag shorthand_ consists of a valid [tag handle] followed by a non-empty
+Tag Shorthands
+:
+A _tag shorthand_ consists of a valid [tag handle] followed by a non-empty
 suffix.
 The [tag handle] must be associated with a [prefix], either by default or by
 using a "`TAG`" directive.
 The resulting [parsed] [tag] is the concatenation of the [prefix] and the
 suffix and must either begin with "`!`" (a [local tag]) or be a valid URI (a
 [global tag]).
-
-: The choice of [tag handle] is a [presentation detail] and must not be used to
+:
+The choice of [tag handle] is a [presentation detail] and must not be used to
 convey [content] information.
 In particular, the [tag handle] may be discarded once [parsing] is completed.
-
-: The suffix must not contain any "`!`" character.
+:
+The suffix must not contain any "`!`" character.
 This would cause the tag shorthand to be interpreted as having a [named tag
 handle].
 In addition, the suffix must not contain the "`[`", "`]`", "`{`", "`}`" and
@@ -3534,22 +3536,22 @@ ERROR:
 <!-- 3:7,3 -->
 
 
-? Non-Specific Tags
-
-: If a [node] has no tag property, it is assigned a [non-specific tag] that
+Non-Specific Tags
+:
+If a [node] has no tag property, it is assigned a [non-specific tag] that
 needs to be [resolved] to a [specific] one.
 This [non-specific tag] is "`!`" for non-[plain scalars] and "`?`" for all
 other [nodes].
 This is the only case where the [node style] has any effect on the [content]
 information.
-
-: It is possible for the tag property to be explicitly set to the "`!`"
+:
+It is possible for the tag property to be explicitly set to the "`!`"
 non-specific tag.
 By [convention], this "disables" [tag resolution], forcing the [node] to be
 interpreted as "`tag:yaml.org,2002:seq`", "`tag:yaml.org,2002:map`" or
 "`tag:yaml.org,2002:str`", according to its [kind].
-
-: There is no way to explicitly specify the "`?`" non-specific tag.
+:
+There is no way to explicitly specify the "`?`" non-specific tag.
 This is intentional.
 
 ```
@@ -4997,25 +4999,25 @@ interpreted.
 YAML provides three chomping methods:
 
 
-? Strip
-
-: _Stripping_ is specified by the _"`-`" chomping indicator_.
+Strip
+:
+_Stripping_ is specified by the _"`-`" chomping indicator_.
 In this case, the final [line break] and any trailing [empty lines] are
 excluded from the [scalar's content].
 
 
-? Clip
-
-: _Clipping_ is the default behavior used if no explicit chomping indicator is
+Clip
+:
+_Clipping_ is the default behavior used if no explicit chomping indicator is
 specified.
 In this case, the final [line break] character is preserved in the [scalar's
 content].
 However, any trailing [empty lines] are excluded from the [scalar's content].
 
 
-? Keep
-
-: _Keeping_ is specified by the _"`+`" chomping indicator_.
+Keep
+:
+_Keeping_ is specified by the _"`+`" chomping indicator_.
 In this case, the final [line break] and any trailing [empty lines] are
 considered to be part of the [scalar's content].
 These additional lines are not subject to [folding].
@@ -6238,17 +6240,17 @@ with the above `l-yaml-stream` production.
 Some common use case that can take advantage of the YAML stream structure are:
 
 
-? Appending to Streams
-
-: Allowing multiple [documents] in a single stream makes YAML suitable for log
+Appending to Streams
+:
+Allowing multiple [documents] in a single stream makes YAML suitable for log
 files and similar [applications].
 Note that each [document] is independent of the rest, allowing for
 heterogeneous log file entries.
 
 
-? Concatenating Streams
-
-: Concatenating two YAML streams requires both to use the same [character
+Concatenating Streams
+:
+Concatenating two YAML streams requires both to use the same [character
 encoding].
 In addition, it is necessary to separate the last [document] of the first
 stream and the first [document] of the second stream.
@@ -6256,9 +6258,9 @@ This is easily ensured by inserting a [document end marker] between the two
 streams.
 
 
-? Communication Streams
-
-: The [document end marker] allows signaling the end of a [document] without
+Communication Streams
+:
+The [document end marker] allows signaling the end of a [document] without
 closing the stream or starting the next [document].
 This allows the receiver to complete processing a [document] without having to
 wait for the next one to arrive.
@@ -6285,19 +6287,19 @@ option.
 
 #### #. Generic Mapping
 
-? URI
-
-: `tag:yaml.org,2002:map`
-
-
-? Kind
-
-: [Mapping].
+URI
+:
+`tag:yaml.org,2002:map`
 
 
-? Definition
+Kind
+:
+[Mapping].
 
-: [Represents] an associative container, where each [key] is unique in the
+
+Definition
+:
+[Represents] an associative container, where each [key] is unique in the
 association and mapped to exactly one [value].
 YAML places no restrictions on the type of [keys]; in particular, they are not
 restricted to being [scalars].
@@ -6319,19 +6321,19 @@ Flow style: !!map { Clark: Evans, Ingy: döt Net, Oren: Ben-Kiki }
 
 #### #. Generic Sequence
 
-? URI
-
-: `tag:yaml.org,2002:seq`
-
-
-? Kind
-
-: [Sequence].
+URI
+:
+`tag:yaml.org,2002:seq`
 
 
-? Definition
+Kind
+:
+[Sequence].
 
-: [Represents] a collection indexed by sequential integers starting with zero.
+
+Definition
+:
+[Represents] a collection indexed by sequential integers starting with zero.
 Example [bindings] to [native] types include Perl's array, Python's list or
 tuple and Java's array or Vector.
 
@@ -6350,26 +6352,26 @@ Flow style: !!seq [ Clark Evans, Ingy döt Net, Oren Ben-Kiki ]
 
 #### #. Generic String
 
-? URI
-
-: `tag:yaml.org,2002:str`
-
-
-? Kind
-
-: [Scalar].
+URI
+:
+`tag:yaml.org,2002:str`
 
 
-? Definition
+Kind
+:
+[Scalar].
 
-: [Represents] a Unicode string, a sequence of zero or more Unicode characters.
+
+Definition
+:
+[Represents] a Unicode string, a sequence of zero or more Unicode characters.
 This type is usually [bound] to the [native] language's string type or, for
 languages lacking one (such as C), to a character array.
 
 
-? Canonical Form:
-
-: The obvious.
+Canonical Form:
+:
+The obvious.
 
 
 **Example #. `!!str` Examples**
@@ -6409,19 +6411,19 @@ The JSON [schema] uses the following [tags] in addition to those defined by the
 
 #### #. Null
 
-? URI
-
-: `tag:yaml.org,2002:null`
-
-
-? Kind
-
-: [Scalar].
+URI
+:
+`tag:yaml.org,2002:null`
 
 
-? Definition
+Kind
+:
+[Scalar].
 
-: [Represents] the lack of a value.
+
+Definition
+:
+[Represents] the lack of a value.
 This is typically [bound] to a [native] null-like value (e.g., `undef` in Perl,
 `None` in Python).
 Note that a null is different from an empty string.
@@ -6429,9 +6431,9 @@ Also, a [mapping] entry with some [key] and a null [value] is valid and
 different from not having that [key] in the [mapping].
 
 
-? Canonical Form
-
-: `null`.
+Canonical Form
+:
+`null`.
 
 **Example #. `!!null` Examples**
 
@@ -6443,26 +6445,26 @@ key with null value: !!null null
 
 #### #. Boolean
 
-? URI
-
-: `tag:yaml.org,2002:bool`
-
-
-? Kind
-
-: [Scalar].
+URI
+:
+`tag:yaml.org,2002:bool`
 
 
-? Definition
+Kind
+:
+[Scalar].
 
-: [Represents] a true/false value.
+
+Definition
+:
+[Represents] a true/false value.
 In languages without a [native] Boolean type (such as C), they are usually
 [bound] to a native integer type, using one for true and zero for false.
 
 
-? Canonical Form
-
-: Either `true` or `false`.
+Canonical Form
+:
+Either `true` or `false`.
 
 
 **Example #. `!!bool` Examples**
@@ -6475,28 +6477,28 @@ Pluto is a planet: !!bool false
 
 #### #. Integer
 
-? URI
-
-: `tag:yaml.org,2002:int`
-
-
-? Kind
-
-: [Scalar].
+URI
+:
+`tag:yaml.org,2002:int`
 
 
-? Definition
+Kind
+:
+[Scalar].
 
-: [Represents] arbitrary sized finite mathematical integers.
+
+Definition
+:
+[Represents] arbitrary sized finite mathematical integers.
 Scalars of this type should be [bound] to a [native] integer data type, if
 possible.
-
-: Some languages (such as Perl) provide only a "number" type that allows for
+:
+Some languages (such as Perl) provide only a "number" type that allows for
 both integer and floating-point values.
 A YAML [processor] may use such a type for integers as long as they round-trip
 properly.
-
-: In some languages (such as C), an integer may overflow the [native] type's
+:
+In some languages (such as C), an integer may overflow the [native] type's
 storage capability.
 A YAML [processor] may reject such a value as an error, truncate it with a
 warning or find some other manner to round-trip it.
@@ -6504,9 +6506,9 @@ In general, integers representable using 32 binary digits should safely
 round-trip through most systems.
 
 
-? Canonical Form
-
-: Decimal integer notation, with a leading "`-`" character for negative values,
+Canonical Form
+:
+Decimal integer notation, with a leading "`-`" character for negative values,
 matching the regular expression `0 | -? [1-9] [0-9]*`
 
 
@@ -6521,27 +6523,27 @@ positive: !!int 34
 
 #### #. Floating Point
 
-? URI
-
-: `tag:yaml.org,2002:float`
-
-
-? Kind
-
-: [Scalar].
+URI
+:
+`tag:yaml.org,2002:float`
 
 
-? Definition
+Kind
+:
+[Scalar].
 
-: [Represents] an approximation to real numbers, including three special values
+
+Definition
+:
+[Represents] an approximation to real numbers, including three special values
 (positive and negative infinity and "not a number").
-
-: Some languages (such as Perl) provide only a "number" type that allows for
+:
+Some languages (such as Perl) provide only a "number" type that allows for
 both integer and floating-point values.
 A YAML [processor] may use such a type for floating-point numbers, as long as
 they round-trip properly.
-
-: Not all floating-point values can be stored exactly in any given [native]
+:
+Not all floating-point values can be stored exactly in any given [native]
 type.
 Hence a float value may change by "a small amount" when round-tripped.
 The supported range and accuracy depends on the implementation, though 32 bit
@@ -6550,9 +6552,9 @@ Since YAML does not specify a particular accuracy, using floating-point
 [mapping keys] requires great care and is not recommended.
 
 
-? Canonical Form
-
-: Either `0`, `.inf`, `-.inf`, `.nan` or scientific notation matching the
+Canonical Form
+:
+Either `0`, `.inf`, `-.inf`, `.nan` or scientific notation matching the
 regular expression  
 `-? [1-9] ( \. [0-9]* [1-9] )? ( e [-+] [1-9] [0-9]* )?`.
 

--- a/test/test-format-markdown.sh
+++ b/test/test-format-markdown.sh
@@ -2,8 +2,17 @@
 
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/setup"
 
-find "$SPEC" -name '*.md' |
+find .. -type f -name '*.md' |
 while read -r file; do
+  echo "============================== $file"
+  [[ $file == */RFC* ]] && continue
+  [[ $file == */story/* ]] && continue
+  [[ $file == *ReadMe* ]] && continue
+  [[ $file == *www/main* ]] && continue
+  [[ $file == *contributing* ]] && continue
+  [[ $file == *pull_request_template* ]] && continue
+  [[ $file == *gloss* ]] && continue
+  [[ $file == *spec/1.2/spec.md* ]] && continue
 
   temp=/tmp/$(basename "$file")
 
@@ -11,5 +20,4 @@ while read -r file; do
 
   ( set -x; diff -u "$file" "$temp" ||
     die "spec.md not properly formatted" )
-
 done

--- a/test/test-format-markdown.sh
+++ b/test/test-format-markdown.sh
@@ -4,14 +4,13 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/setup"
 
 find .. -type f -name '*.md' |
 while read -r file; do
-  echo "============================== $file"
-  [[ $file == */RFC* ]] && continue
+  [[ $file == */rfc/RFC-* ]] && continue
+  [[ $file == */www/main/index.md ]] && continue
   [[ $file == */story/* ]] && continue
-  [[ $file == *ReadMe* ]] && continue
+  [[ $file == */2009/ReadMe* ]] && continue
   [[ $file == *www/main* ]] && continue
   [[ $file == *contributing* ]] && continue
   [[ $file == *pull_request_template* ]] && continue
-  [[ $file == *gloss* ]] && continue
   [[ $file == *spec/1.2/spec.md* ]] && continue
 
   temp=/tmp/$(basename "$file")

--- a/tool/bin/format-markdown
+++ b/tool/bin/format-markdown
@@ -14,10 +14,14 @@ sub out {
   print encode('UTF-8', $_[0], Encode::FB_CROAK);
 }
 sub peek {
-  @l ? $l[0] : '';
+  $_ = @l ? $l[0] : '';
 }
 sub take {
-  shift(@l);
+  $_ = shift(@l);
+}
+sub poke {
+  unshift @l, @_ ? (shift) : $_;
+  $_ = @l ? $l[0] : '';
 }
 sub give {
   unshift(@l, "$_[0]\n");
@@ -164,6 +168,8 @@ sub comm {
   }
   space;
 }
+
+
 
 sub unknown {
   my $line = take;

--- a/tool/bin/format-markdown
+++ b/tool/bin/format-markdown
@@ -77,7 +77,7 @@ sub lines {
 sub wrap {
   my $end = shift;
   my @l;
-  while (peek =~ /./) {
+  while (peek =~ /./ and peek !~ /^:/) {
     my $line = take;
     chomp $line;
     $line =~ s/^\ +(?=\S)(?!\*)//;
@@ -124,8 +124,12 @@ sub line {
 }
 
 sub para {
-  my $end = sub { $_[0] =~ /(  |\.)$/ };
+  my $end = sub { $_[0] =~ /(  |[\.\!\?])$/ };
   wrap $end;
+}
+
+sub ddef {
+  out take;
 }
 
 sub list {
@@ -165,11 +169,10 @@ sub comm {
     while (peek !~ /-->$/) {
       out take;
     }
+    out take;
   }
   space;
 }
-
-
 
 sub unknown {
   my $line = take;
@@ -202,12 +205,13 @@ sub main {
     lis2 and next if $peek =~ /^\ \ \S/;
     tabl and next if $peek =~ /^\|\ /;
     comm and next if $peek =~ /^<!--/;
+    ddef and next if $peek =~ /^:\n/;
     para and next if $peek =~ /^(
       [\w\#\*"`] |
       \[\w |
       \!\[ |
       \(\w |
-      [\?\:\>]\ |
+      \>\ |
       \[\"\*\*
     )/x;
 

--- a/tool/bin/markydown-to-kramdown
+++ b/tool/bin/markydown-to-kramdown
@@ -102,7 +102,7 @@ sub parse_sections {
 
     # Unordered list:
     s/\A
-      (
+      ([ ]*
         $ial*
         $li
         $line_not_blank*
@@ -125,7 +125,7 @@ sub parse_sections {
 
     # Regular paragraph:
     s/\A
-      (
+      ([ ]*
         (?:
           (?:$b|-1$s|\`x|\[[\w\"\*\`]|`[\(]|<http|[\w\"\(])
           .*\n

--- a/tool/bin/markydown-to-kramdown
+++ b/tool/bin/markydown-to-kramdown
@@ -100,9 +100,23 @@ sub parse_sections {
     s/\A\? (.*)\n+//
       and push @s, {dt => $1} and next;
 
+    # Definition definition:
+    s{\A
+      (
+        : (?:\n|$s+) $line
+        (?:
+          \S $line
+        )*?
+      )
+      (?:
+        (?= : ) |
+        \n+
+      )
+    }{}x and push @s, {dd => $1} and next;
+
     # Unordered list:
     s/\A
-      ([ ]*
+      (
         $ial*
         $li
         $line_not_blank*
@@ -125,14 +139,14 @@ sub parse_sections {
 
     # Regular paragraph:
     s/\A
-      ([ ]*
+      (
         (?:
-          (?:$b|-1$s|\`x|\[[\w\"\*\`]|`[\(]|<http|[\w\"\(])
+          (?:$b|-1$s|\`x|\[[\w\"\*\`]|`[\(]|<http|[\w\"\(]|\`\w)
           .*\n
         )+
       )
       (?:
-        (?= $code) |
+        (?= $code | : ) |
         \z |
         \n+
       )
@@ -149,17 +163,6 @@ sub parse_sections {
       )
       \n+
     }{}x and push @s, {indent => $1} and next;
-
-    # Definition definition:
-    s{\A
-      (
-        : $s+ $line
-        (?:
-          \S $line
-        )*
-      )
-      \n+
-    }{}x and push @s, {dd => $1} and next;
 
     s{
       \A(
@@ -180,9 +183,6 @@ sub parse_sections {
 
     s/\A(\* .*\n(?:  \S.*\n|\n(?=  \S))+)\n+//
       and push @s, {ul => $1} and next;
-
-    s/\A(\`\w.*\n)\n+//
-      and push @s, {p => $1} and next;
 
     s/\A((?:\| .*\n)+)\n+//
       and push @s, {table => $1} and next;
@@ -355,6 +355,7 @@ sub fmt_p {
 }
 
 sub fmt_dd {
+  s/^:\n(\S)/: $1/ or die $_;
   format_links();
 }
 

--- a/tool/docker/markydown-to-kramdown/docker.mk
+++ b/tool/docker/markydown-to-kramdown/docker.mk
@@ -1,3 +1,3 @@
 DOCKER_BIN := markydown-to-kramdown
 DOCKER_IMAGE_NAME := yaml-spec-markydown-to-kramdown
-DOCKER_IMAGE_TAG := 0.0.8
+DOCKER_IMAGE_TAG := 0.0.9

--- a/www/ReadMe.md
+++ b/www/ReadMe.md
@@ -105,6 +105,7 @@ For instance the post-processed forms might have a lot more Markdown HTML in
 them.
 
 The intent is to:
+
 * Keep the sources as simple and clean as possible.
 * Have the Markdown files render pretty good in the GitHub views of them.
 * Introduce a few powerful but not Markdown syntaxes.

--- a/www/main/playground/index.md
+++ b/www/main/playground/index.md
@@ -48,6 +48,7 @@ here.
 
 Assuming you have [Docker installed](https://docs.docker.com/get-docker/), just
 run this command from a terminal:
+
 ```
 docker run --rm -p 31337:31337 \
   yamlio/playground-sandbox:0.0.3 https
@@ -85,14 +86,14 @@ browsers.
 
 * Firefox
   * Type `about:config` into the browser URL location
-  * Search for `security.fileuri.strict_origin_policy` in the "Search
-    preference name" box
+  * Search for `security.fileuri.strict_origin_policy` in the "Search preference
+    name" box
   * Change value from `true` to `false`
   * Restart Firefox
 
 That's everything.
-You should be all set to use all the playground things that need to
-run untrusted input on a server!
+You should be all set to use all the playground things that need to run
+untrusted input on a server!
 
 We'll keep looking for ways to make this simpler.
 If you have ideas, let us know!


### PR DESCRIPTION
Reformat the glossary page to use definition lists now that the m2k script supports them.

This requires a minor revision to m2k, which in turn requires a minor fix in the spec document.

<!-- The following lines must be present and unmodified for every pull request
     to this repository or the request will be closed -->
By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
