### PR TITLE
Production comments and line endings refactor

### DIFF
--- a/spec/1.3.0/spec.md
+++ b/spec/1.3.0/spec.md
@@ -6107,11 +6107,8 @@ folded-whitespace(n,c) ::=
 
 ```
 comment-lines ::=
-  (
-      comment-line
-    | <start-of-line>
-  )
-  comment-line*
+    comment-line+
+  | <start-of-line>
 ```
 
 ```

--- a/spec/1.3.0/spec.md
+++ b/spec/1.3.0/spec.md
@@ -5061,7 +5061,7 @@ yaml-stream ::=
       )
     | byte-order-mark
     | blanks-and-maybe-comment-and-end-of-line
-    | explicit-document
+    | start-indicator-and-document
   )*
 ```
 

--- a/spec/1.3.0/spec.md
+++ b/spec/1.3.0/spec.md
@@ -1959,7 +1959,7 @@ A folded non-[empty line] may end with either of the above [line breaks].
 ```
 
 **Legend:**
-* [b-l-trimmed(n,c)] <!-- 2:10 3 4 5 -->
+* [trimmed] <!-- 2:10 3 4 5 -->
 * [break-as-space] <!-- 6:5 -->
 
 

--- a/spec/1.3.0/spec.md
+++ b/spec/1.3.0/spec.md
@@ -5140,9 +5140,8 @@ forbidden-content ::=
     | document-end-indicator
   )
   (
-      line-break-character
+      line-ending
     | blank-character
-    | <end-of-input>
   )
 ```
 
@@ -6369,7 +6368,8 @@ non-space-character ::=
 ```
 non-break-character ::=
     yaml-character
-  - line-break-character
+  - x0A
+  - x0D
   - byte-order-mark
 ```
 
@@ -6405,12 +6405,6 @@ line-break ::=
     )
   | x0D
   | x0A
-```
-
-```
-line-break-character ::=
-    x0A
-  | x0D
 ```
 
 

--- a/spec/1.3.0/spec.md
+++ b/spec/1.3.0/spec.md
@@ -2064,7 +2064,7 @@ key:····# Comment↓
 ```
 
 **Legend:**
-* [comment-to-end-of-line] <!-- 1:9,9 -->
+* [comment-content] <!-- 1:9,9 -->
 * [break-or-end-of-input] <!-- ↓ 2:8,5 -->
 * [comment-line] <!-- 1:5, 2:8,5 -->
 
@@ -5491,7 +5491,7 @@ line-keep-empty(n) ::=
 ```
 line-trail-comments(n) ::=
   indentation-spaces-less-than(n)
-  comment-to-end-of-line
+  comment-content
   break-or-end-of-input
   comment-line*
 ```
@@ -6114,12 +6114,12 @@ comment-lines ::=
 ```
 comment-line ::=
   separation-blanks
-  comment-to-end-of-line?
+  comment-content?
   break-or-end-of-input
 ```
 
 ```
-comment-to-end-of-line ::=
+comment-content ::=
   '#'
   non-break-character*
 ```

--- a/spec/1.3.0/spec.md
+++ b/spec/1.3.0/spec.md
@@ -5446,7 +5446,10 @@ block-scalar-indicators(t) ::=
         block-scalar-indentation-indicator
       )
   )
-  comment-line
+  (
+      comment-line
+    | line-ending
+  )
 ```
 
 ```

--- a/spec/1.3.0/spec.md
+++ b/spec/1.3.0/spec.md
@@ -3585,7 +3585,7 @@ keep: |+
 ```
 
 **Legend:**
-* [break-non-content] <!-- 2:7 -->
+* [line-break] <!-- 2:7 -->
 * [break-as-line-feed] <!-- 4:7 6:7 -->
 
 
@@ -5462,7 +5462,7 @@ block-scalar-chomping-indicator(CLIP)  ::= ""
 ```
 
 ```
-block-scalar-chomp-last(STRIP) ::= break-non-content  | <end-of-input>
+block-scalar-chomp-last(STRIP) ::= line-break | <end-of-input>
 block-scalar-chomp-last(CLIP)  ::= break-as-line-feed | <end-of-input>
 block-scalar-chomp-last(KEEP)  ::= break-as-line-feed | <end-of-input>
 ```
@@ -5477,7 +5477,7 @@ block-scalar-chomp-empty(n,KEEP)  ::= line-keep-empty(n)
 line-strip-empty(n) ::=
   (
     indentation-spaces-less-or-equal(n)
-    break-non-content
+    line-break
   )*
   line-trail-comments(n)?
 ```
@@ -5812,7 +5812,7 @@ non-break-double-quoted-character ::=
 double-quoted-line-continuation(n) ::=
   blank-character*
   '\'
-  break-non-content
+  line-break
   empty-line(n,FLOW-IN)*
   indentation-spaces-plus-maybe-more(n)
 ```
@@ -6096,7 +6096,7 @@ flow-folded-whitespace(n) ::=
 ```
 folded-whitespace(n,c) ::=
     (
-      break-non-content
+      line-break
       empty-line(n,c)+
     )
   | break-as-space
@@ -6126,7 +6126,7 @@ comment-content ::=
 
 ```
 line-ending ::=
-    break-non-content
+    line-break
   | <end-of-input>
 ```
 
@@ -6394,11 +6394,6 @@ break-as-space ::=
 
 ```
 break-as-line-feed ::=
-  line-break
-```
-
-```
-break-non-content ::=
   line-break
 ```
 

--- a/spec/1.3.0/spec.md
+++ b/spec/1.3.0/spec.md
@@ -2065,7 +2065,7 @@ key:····# Comment↓
 
 **Legend:**
 * [comment-content] <!-- 1:9,9 -->
-* [break-or-end-of-input] <!-- ↓ 2:8,5 -->
+* [line-ending] <!-- ↓ 2:8,5 -->
 * [comment-line] <!-- 1:5, 2:8,5 -->
 
 
@@ -5492,7 +5492,7 @@ line-keep-empty(n) ::=
 line-trail-comments(n) ::=
   indentation-spaces-less-than(n)
   comment-content
-  break-or-end-of-input
+  line-ending
   comment-line*
 ```
 
@@ -6115,7 +6115,7 @@ comment-lines ::=
 comment-line ::=
   separation-blanks
   comment-content?
-  break-or-end-of-input
+  line-ending
 ```
 
 ```
@@ -6125,7 +6125,7 @@ comment-content ::=
 ```
 
 ```
-break-or-end-of-input ::=
+line-ending ::=
     break-non-content
   | <end-of-input>
 ```

--- a/spec/1.3.0/spec.md
+++ b/spec/1.3.0/spec.md
@@ -6126,12 +6126,6 @@ comment-content ::=
   non-break-character*
 ```
 
-```
-line-ending ::=
-    line-break
-  | <end-of-input>
-```
-
 
 ### #. Empty Lines
 
@@ -6388,7 +6382,13 @@ space-character ::=
 ```
 
 
-### #. Line Break Characters
+### #. Line Ending Productions
+
+```
+line-ending ::=
+    line-break
+  | <end-of-input>
+```
 
 ```
 break-as-space ::=

--- a/spec/1.3.0/spec.md
+++ b/spec/1.3.0/spec.md
@@ -2066,7 +2066,7 @@ key:····# Comment↓
 **Legend:**
 * [comment-to-end-of-line] <!-- 1:9,9 -->
 * [break-or-end-of-input] <!-- ↓ 2:8,5 -->
-* [maybe-comment-and-end-of-line] <!-- 1:5, 2:8,5 -->
+* [comment-line] <!-- 1:5, 2:8,5 -->
 
 
 Outside [scalar content], comments may appear on a line of their own,
@@ -2089,8 +2089,8 @@ characters is taken to be a comment line.
 ```
 
 **Legend:**
-* [maybe-comment-and-end-of-line] <!-- 1:3, 2:4 3 -->
-* [blanks-and-maybe-comment-and-end-of-line] <!-- 1 2 3 -->
+* [comment-line] <!-- 1:3, 2:4 3 -->
+* [comment-line] <!-- 1 2 3 -->
 
 
 In most cases, when a line may end with a comment, YAML allows it to be
@@ -2112,8 +2112,8 @@ key:····# Comment↓
 ```
 
 **Legend:**
-* [maybe-comment-and-end-of-line] <!-- 1:5, 3:8 -->
-* [blanks-and-maybe-comment-and-end-of-line] <!-- 2 4 -->
+* [comment-line] <!-- 1:5, 3:8 -->
+* [comment-line] <!-- 2 4 -->
 * [comment-lines] <!-- 1:5, 2 3:8 4 -->
 
 
@@ -5060,7 +5060,7 @@ yaml-stream ::=
         any-document?
       )
     | byte-order-mark
-    | blanks-and-maybe-comment-and-end-of-line
+    | comment-line
     | start-indicator-and-document
   )*
 ```
@@ -5068,7 +5068,7 @@ yaml-stream ::=
 ```
 document-prefix ::=
   byte-order-mark?
-  blanks-and-maybe-comment-and-end-of-line*
+  comment-line*
 ```
 
 ```
@@ -5447,7 +5447,7 @@ block-scalar-indicators(t) ::=
         block-scalar-indentation-indicator
       )
   )
-  maybe-comment-and-end-of-line
+  comment-line
 ```
 
 ```
@@ -5493,7 +5493,7 @@ line-trail-comments(n) ::=
   indentation-spaces-less-than(n)
   comment-to-end-of-line
   break-or-end-of-input
-  blanks-and-maybe-comment-and-end-of-line*
+  comment-line*
 ```
 
 
@@ -6108,25 +6108,16 @@ folded-whitespace(n,c) ::=
 ```
 comment-lines ::=
   (
-      maybe-comment-and-end-of-line
+      comment-line
     | <start-of-line>
   )
-  blanks-and-maybe-comment-and-end-of-line*
+  comment-line*
 ```
 
 ```
-blanks-and-maybe-comment-and-end-of-line ::=
+comment-line ::=
   separation-blanks
   comment-to-end-of-line?
-  break-or-end-of-input
-```
-
-```
-maybe-comment-and-end-of-line ::=
-  (
-    separation-blanks
-    comment-to-end-of-line?
-  )?
   break-or-end-of-input
 ```
 


### PR DESCRIPTION
This PR tries to simplify the rules around comments and whitespace.

The first commit is critical to review. I can't say yet with 100% certainty that it's right but I could not find a situation where it would not work.

The two productions were not exactly the same, but in the context of all the productions I think they behave exactly the same.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
