### PR TITLE
Use Kramdown directly

### DIFF
--- a/.bpan/run-or-docker.bash
+++ b/.bpan/run-or-docker.bash
@@ -26,6 +26,7 @@ run() (
       *.bash) lang=bash ;;
       *.pl) lang=perl ;;
       *.py) lang=python3 ;;
+      *.rb) lang=ruby ;;
       *) die "Don't recognize language of '$prog'" ;;
     esac
   fi

--- a/bin/kramdown-to-html
+++ b/bin/kramdown-to-html
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
 
-# XXX Using this hack until we can figure out how to get the same results
-# directly from kramdown.
+version=1.3.0.1
 
-docker run -i --rm jekyll/jekyll \
-  bash -c '(
-    (
-      echo "kramdown:"
-      echo "  parse_block_html: true"
-    ) > _config.yml
-    echo ---
-    echo ---
-    cat
-  ) > foo.md &&
-  jekyll build >/dev/null &&
-  cat ./_site/foo.html'
+source "${ROOT:-$PWD}/.bpan/run-or-docker.bash"
+
+check() (
+  need ruby 2.3
+  need ruby kramdown
+  need ruby kramdown-parser-gfm
+)
+
+dockerfile() (
+  from alpine
+  gem kramdown
+  gem kramdown-parser-gfm
+)
+
+run "$@"

--- a/bin/kramdown-to-html.rb
+++ b/bin/kramdown-to-html.rb
@@ -1,0 +1,14 @@
+require 'kramdown'
+
+options = {
+  input: 'GFM',
+  parse_block_html: true,
+  hard_wrap: false,
+  syntax_highlighter_opts: {
+    default_lang: 'plaintext',
+    guess_lang: true,
+  }
+}
+
+document = Kramdown::Document.new(STDIN.read, options)
+STDOUT.write document.to_html


### PR DESCRIPTION
Replace the Jekyll hack with a simply Ruby script that invokes Kramdown.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
