### PR TITLE
Pin ruby version and gem versions

### DIFF
--- a/.bpan/run-or-docker.bash
+++ b/.bpan/run-or-docker.bash
@@ -197,14 +197,13 @@ need-modules() {
       ruby)
         list=$(gem list)
         if [[ $module == *=* ]]; then
-          want="${module//./\\.}"
-          want="${want/=/ (.*})"
+          version=${module#*=}
+          module=${module%=*}
         else
-          want="$module.*"
+          version=0
         fi
-        want="^$want$"
-        grep "$want" <<<"$list" ||
-          fail "'$cmd' requires Ruby module '$module'"
+        (set -x; ruby -e "gem '$module', '>=$version'") &>/dev/null ||
+          fail "'$cmd' requires Ruby module '$module' >= v$version"
         ;;
       *) die "Can't check module '$module' for '$cmd'" ;;
     esac

--- a/bin/kramdown-to-html
+++ b/bin/kramdown-to-html
@@ -5,9 +5,9 @@ version=1.3.0.1
 source "${ROOT:-$PWD}/.bpan/run-or-docker.bash"
 
 check() (
-  need ruby 2.3
-  need ruby kramdown
-  need ruby kramdown-parser-gfm
+  need ruby 2.7
+  need ruby kramdown=2.3.1
+  need ruby kramdown-parser-gfm=1.1.0
 )
 
 dockerfile() (

--- a/bin/kramdown-to-html.rb
+++ b/bin/kramdown-to-html.rb
@@ -1,4 +1,5 @@
 require 'kramdown'
+require 'kramdown-parser-gfm'
 
 options = {
   input: 'GFM',


### PR DESCRIPTION
Also needed to require `kramdown-parser-gfm` explicitly.

Not sure why, but it wouldn't run natively on my laptop without that line.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
