### PR TITLE
Create internal links in Python

### DIFF
--- a/spec/1.3.0/bin/html-to-html
+++ b/spec/1.3.0/bin/html-to-html
@@ -6,12 +6,12 @@ source "${ROOT:-$PWD}/.bpan/run-or-docker.bash"
 
 check() (
   need python3 3.8
-  need python bs4 roman
+  need python bs4 roman yaml
 )
 
 dockerfile() (
   from alpine
-  pip beautifulsoup4 roman
+  pip beautifulsoup4 roman pyyaml
 )
 
 run "$@"

--- a/spec/1.3.0/bin/html-to-html.py
+++ b/spec/1.3.0/bin/html-to-html.py
@@ -1,5 +1,4 @@
 import sys
-import os.path
 import re
 from copy import copy
 import string
@@ -242,8 +241,7 @@ def create_internal_links():
 
 
 def make_link_index():
-    root_path = sys.argv[1]
-    links_path = os.path.join(root_path, 'spec', '1.3.0', 'links.yaml')
+    links_path = sys.argv[2]
 
     with open(links_path, 'r') as file:
         links_text = file.read()

--- a/spec/1.3.0/bin/html-to-html.py
+++ b/spec/1.3.0/bin/html-to-html.py
@@ -9,7 +9,8 @@ import yaml
 
 
 def warn(*args):
-    print(*args, file=sys.stderr)
+    sys.stderr.write('\033[0;31m')
+    print(*args, file=sys.stderr, end='\033[0m\n')
 
 
 HEADING_EXPR = re.compile(r'\Ah(\d)\Z')

--- a/spec/1.3.0/bin/markydown-to-html
+++ b/spec/1.3.0/bin/markydown-to-html
@@ -20,4 +20,4 @@ perl -p0e 's/\A---\n.*?\n---\n//s' |
 
 kramdown-to-html "$root" |
 
-html-to-html "$root"
+html-to-html "$root" "$links"


### PR DESCRIPTION
The XML diff says that this changes one link href (from `#resolved-tags` to `#non-specific-tags`). Since the old link was broken and the new one isn't, I haven't bothered to track that down. This makes this technically a spec change.

The new implementation uses a more reliable method of finding broken internal links. Apparently there are quite a few (not from this PR). This is probably due to issues with the ID autogeneration, which I plan to address in a future PR.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
