### PR TITLE
Generate heading and <dt> IDs in Python

### DIFF
--- a/bin/kramdown-to-html.rb
+++ b/bin/kramdown-to-html.rb
@@ -5,10 +5,11 @@ options = {
   input: 'GFM',
   parse_block_html: true,
   hard_wrap: false,
+  auto_ids: false,
   syntax_highlighter_opts: {
     default_lang: 'plaintext',
     guess_lang: true,
-  }
+  },
 }
 
 document = Kramdown::Document.new(STDIN.read, options)

--- a/spec/1.3.0/bin/html-to-html
+++ b/spec/1.3.0/bin/html-to-html
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-version=1.3.0.5
+version=1.3.0.6
 
 source "${ROOT:-$PWD}/.bpan/run-or-docker.bash"
 

--- a/spec/1.3.0/bin/html-to-html.py
+++ b/spec/1.3.0/bin/html-to-html.py
@@ -8,40 +8,15 @@ library_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'lib')
 
 sys.path.append(library_path)
 
-from transformations import transform, slugify
-
-
-def make_link_index():
-    links_path = sys.argv[2]
-
-    with open(links_path, 'r') as file:
-        links_text = file.read()
-        links = yaml.load(links_text, Loader=yaml.SafeLoader)
-
-    ids = [
-        slugify(element['id'])
-        for element in soup.find_all(lambda tag: tag.has_attr('id'))
-    ]
-
-    overrides = [
-        (slugify(str(source)), target)
-        for target, sources in links.items()
-        if sources is not None
-        for source in sources
-    ]
-
-    return {
-        **{ slug+'s': target for slug, target in overrides },
-        **{ id: id for id in ids },
-        **{ slug: target for slug, target in overrides },
-    }
+from transformations import transform
 
 
 html = sys.stdin.read()
 soup = BeautifulSoup(html, "html.parser")
 
-link_index = make_link_index()
+with open(sys.argv[2], 'r') as file:
+    links = yaml.load(file.read(), Loader=yaml.SafeLoader)
 
-transform(soup, link_index)
+transform(soup, links)
 
 sys.stdout.write(str(soup))

--- a/spec/1.3.0/bin/lib/transformations.py
+++ b/spec/1.3.0/bin/lib/transformations.py
@@ -69,6 +69,8 @@ def transform(soup, links):
 
     make_outline(list(toc_header.parent.next_siblings))
 
+    auto_id_dts(soup)
+
     number_sections(soup, 'roman', 1)
     number_headings(soup)
     number_examples(soup)
@@ -108,6 +110,11 @@ def make_outline(elements):
                 stack[-1].append(section.extract())
 
             stack.append(section)
+
+
+def auto_id_dts(soup):
+    for dt in soup.find_all('dt'):
+        dt['id'] = slugify(''.join(dt.strings))
 
 
 def number_sections(parent, section_format, start_index):

--- a/spec/1.3.0/bin/markydown-to-kramdown
+++ b/spec/1.3.0/bin/markydown-to-kramdown
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-version=1.3.0.2
+version=1.3.0.3
 
 RUN_OR_DOCKER_PULL=true
 

--- a/spec/1.3.0/bin/markydown-to-kramdown.pl
+++ b/spec/1.3.0/bin/markydown-to-kramdown.pl
@@ -249,11 +249,6 @@ sub fmt_heading {
 
 sub fmt_dt {
   set_dates();
-
-  my $text = $_;
-  my $slug = slugify($text);
-
-  $_ = qq{<div id="$slug"></div>\n\n$text\n};
 }
 
 sub fmt_example {

--- a/spec/1.3.0/bin/markydown-to-kramdown.pl
+++ b/spec/1.3.0/bin/markydown-to-kramdown.pl
@@ -245,13 +245,6 @@ sub fmt_html_block {
 
 sub fmt_heading {
   set_dates();
-
-  return unless /\d\.\s/;
-
-  my $text = $_;
-  my $slug = slugify($text);
-
-  $_ = qq{<div id="$slug"></div>\n$text\n};
 }
 
 sub fmt_dt {

--- a/spec/1.3.0/links.yaml
+++ b/spec/1.3.0/links.yaml
@@ -209,6 +209,8 @@ processes-and-models:
 - processor
 production-parameters:
 - production parameters
+production-syntax:
+- 4
 recognized-and-valid-tags:
 - invalid
 - unrecognized
@@ -274,8 +276,6 @@ special-productions:
 - special-production
 structural-productions:
 - 6
-syntax-conventions:
-- 4
 tags:
 - global
 - global tag


### PR DESCRIPTION
This fixes all of the broken links as a side effect. (Which is why it's marked as a spec change.)

For background, the code in m2d that added IDs to headers broke at some point, presumably when header numbering was moved to the Python script. This was not immediately obvious because Kramdown's automatic header IDs kicked in and worked in many cases, but not in all cases. For unknown reasons, the old link checking code did not detect the broken links, but the more robust link checking code added in #248 did.

The new auto-ID code fixed all of the broken links except for one: `syntax-conventions` in the links index needed to be changed to `production-syntax` as a result of #222.

This implementation differs from the original in one important way. The original implementation added empty `<div>` elements with the autogenerated IDs. This implementation adds the autogenerated IDs to the corresponding `<section>` element in the case of headings, and for `<dt>`s directly on that element.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
