### PR TITLE
Format productions in Python script

### DIFF
--- a/spec/1.3.0/bin/html-to-html
+++ b/spec/1.3.0/bin/html-to-html
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-version=1.3.0.6
+version=1.3.0.7
 
 source "${ROOT:-$PWD}/.bpan/run-or-docker.bash"
 

--- a/spec/1.3.0/bin/lib/bs_util.py
+++ b/spec/1.3.0/bin/lib/bs_util.py
@@ -53,7 +53,12 @@ def replace(element, expr, replacement):
                     if isinstance(replacement, str):
                         element.append(match.expand(replacement))
                     else:
-                        element.append(replacement(match))
+                        r = replacement(match)
+                        if isinstance(r, PageElement):
+                            element.append(r)
+                        else:
+                            for item in r:
+                                element.append(item)
 
                     last_end = end
 

--- a/spec/1.3.0/bin/lib/transformations.py
+++ b/spec/1.3.0/bin/lib/transformations.py
@@ -202,20 +202,35 @@ def format_productions(soup):
         and '::=' in pre.string
         and 'production-' not in pre.string
     ]
+
+    all_names = set()
+
     for i, production in enumerate(productions, 1):
         production_name = PRODUCTION_EXPR.search(production.string).group('name')
+        all_names.add(production_name)
 
+        # production.insert_before(tag('div', id='rule-' + production_name))
         production['id'] = 'rule-' + production_name
         production['class'] = 'rule'
 
-        replace(production, PRODUCTION_EXPR,
-            lambda m: [
-                tag('a', m.group('name'), href='#rule-' + m.group('name')),
-                m.group('args') or '',
-            ] if m.group('definition') is None else m[0]
-        )
-
         production.insert(0, f'[{i}]')
+        production.prettify()
+
+    def link_production(m):
+        name = m.group('name')
+        if m.group('definition') is None:
+            if name not in all_names:
+                warn(f"Warning: Can't find rule {name}")
+
+            return [
+                tag('a', name, href=f'#rule-{name}'),
+                m.group('args') or '',
+            ]
+        else:
+            return m[0]
+
+    for production in productions:
+        replace(production, PRODUCTION_EXPR, link_production)
 
 
 def make_toc(parent):

--- a/spec/1.3.0/bin/lib/transformations.py
+++ b/spec/1.3.0/bin/lib/transformations.py
@@ -203,16 +203,16 @@ def format_productions(soup):
         and 'production-' not in pre.string
     ]
     for i, production in enumerate(productions, 1):
-        m = PRODUCTION_EXPR.search(production.string)
+        production_name = PRODUCTION_EXPR.search(production.string).group('name')
 
-        production.insert_before(tag('div', id='rule-' + m.group('name')))
+        production['id'] = 'rule-' + production_name
         production['class'] = 'rule'
 
         replace(production, PRODUCTION_EXPR,
             lambda m: [
                 tag('a', m.group('name'), href='#rule-' + m.group('name')),
                 m.group('args') or '',
-            ] if not m.group('definition') else m[0]
+            ] if m.group('definition') is None else m[0]
         )
 
         production.insert(0, f'[{i}]')

--- a/spec/1.3.0/bin/lib/transformations.py
+++ b/spec/1.3.0/bin/lib/transformations.py
@@ -210,7 +210,6 @@ def format_productions(soup):
         production_name = PRODUCTION_EXPR.search(production.string).group('name')
         all_names.add(production_name)
 
-        # production.insert_before(tag('div', id='rule-' + production_name))
         production['id'] = 'rule-' + production_name
         production['class'] = 'rule'
 
@@ -222,10 +221,7 @@ def format_productions(soup):
             if name not in all_names:
                 warn(f"Warning: Can't find rule {name}")
 
-            return [
-                tag('a', name, href=f'#rule-{name}'),
-                m.group('args') or '',
-            ]
+            return tag('a', m[0], href=f'#rule-{name}')
         else:
             return m[0]
 

--- a/spec/1.3.0/bin/lib/transformations.py
+++ b/spec/1.3.0/bin/lib/transformations.py
@@ -182,6 +182,7 @@ def number_figures(soup):
 
 
 PRODUCTION_EXPR = re.compile(r'''
+    (?P<comment>\#.*) |
     \b(?P<name>
         [a-z]+(?:-[a-z0-9]+)+
     )\b
@@ -214,11 +215,10 @@ def format_productions(soup):
         production['class'] = 'rule'
 
         production.insert(0, f'[{i}]')
-        production.prettify()
 
     def link_production(m):
         name = m.group('name')
-        if m.group('definition') is None:
+        if m.group('comment') is None and m.group('definition') is None:
             if name not in all_names:
                 warn(f"Warning: Can't find rule {name}")
 

--- a/spec/1.3.0/bin/markydown-to-kramdown
+++ b/spec/1.3.0/bin/markydown-to-kramdown
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-version=1.3.0.3
+version=1.3.0.4
 
 RUN_OR_DOCKER_PULL=true
 

--- a/spec/1.3.0/bin/markydown-to-kramdown.pl
+++ b/spec/1.3.0/bin/markydown-to-kramdown.pl
@@ -340,38 +340,6 @@ sub fmt_indent {}
 my $num = 0;
 sub fmt_pre {
   my $pre = format_pre($_);
-  my $x = $pre;
-  if ($pre =~ s/\b((?!production)[a-z]+-\S+)(\s+::=)/%%%/) {
-    my $rule = $1;
-    my $sep = $2;
-    $num++;
-    $pre =~ s/<pre>/<pre class="rule">[$num]/;
-    $pre =~
-      s{
-        \ (
-          [cs]-l\+
-          .*?
-        )
-        (?=[\(\+\*\?]|\s|\z)
-      }
-      {' ' . rule_link($1)}gex;
-    $pre =~
-      s{
-        \ (
-          (?:[a-z]+)-
-          .*?
-        )
-        (?=[\{\(\+\*\?]|\s|\z)
-      }
-      {' ' . rule_link($1)}gex;
-    $pre =~ s/%%%/$rule$sep/;
-    chomp $pre;
-    $rule =~ s/\(.*//;
-    $pre = <<"...";
-<div id="rule-$rule"></div>
-$pre
-...
-  }
   $_ = $pre;
 }
 


### PR DESCRIPTION
Automatically set IDs and link production names in the Python script.

The first commit is a straight conversion with no change to the output. Subsequent commits:

- Set the ID on the `<pre>` element rather than adding an empty `<div>`.
- Don't link words in comments (e.g. `ws-char` in `# Not followed by non-ws char`).
- Include parameters in the hyperlinks (though not in the IDs/hrefs).

This implementation also prints a warning if it links a rule that does not exist. The old implementation did this several times. Most of these were in comments that shouldn't have been linked, and that's fixed in this PR. However, `flow-plain-scalar-character` incorrectly refers to `non-space-characters` instead of `non-space-character`. That should be fixed in a separate PR.

This is marked as a spec change because of the three points listed above.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
