### PR TITLE
Fix typo in production

### DIFF
--- a/spec/1.3.0/spec.md
+++ b/spec/1.3.0/spec.md
@@ -5561,7 +5561,7 @@ block-plain-scalar-character ::=
 
 ```
 flow-plain-scalar-character ::=
-    non-space-characters
+    non-space-character
   - flow-collection-indicators
 ```
 


### PR DESCRIPTION
The link-checking code in #251 revealed a typo: in the definition of `flow-plain-scalar-character`, `non-space-character` is typo'd as `non-space-characters`. This PR fixes the typo, which was the only remaining broken link warning.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
