### PR TITLE
Python auto dates

### DIFF
--- a/spec/1.3.0/bin/html-to-html
+++ b/spec/1.3.0/bin/html-to-html
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-version=1.3.0.7
+version=1.3.0.8
 
 source "${ROOT:-$PWD}/.bpan/run-or-docker.bash"
 

--- a/spec/1.3.0/bin/lib/transformations.py
+++ b/spec/1.3.0/bin/lib/transformations.py
@@ -1,6 +1,7 @@
 import sys
 import re
 import string
+from datetime import datetime
 
 from roman import toRoman
 
@@ -70,6 +71,7 @@ def transform(soup, links):
     make_outline(list(toc_header.parent.next_siblings))
 
     auto_id_dts(soup)
+    auto_dates(soup)
 
     number_sections(soup, 'roman', 1)
     number_headings(soup)
@@ -117,6 +119,16 @@ def make_outline(elements):
 def auto_id_dts(soup):
     for dt in soup.find_all('dt'):
         dt['id'] = slugify(''.join(dt.strings))
+
+
+DATE_EXPR = re.compile(r'YYYY(.)MM(.)DD')
+SHORT_DATE_EXPR = re.compile(r'YYYY')
+
+
+def auto_dates(soup):
+    today = datetime.today().date()
+    replace(soup, DATE_EXPR, fr'{today.year:04}\g<1>{today.month:02}\g<2>{today.day:02}')
+    replace(soup, SHORT_DATE_EXPR, fr'{today.year:04}')
 
 
 def number_sections(parent, section_format, start_index):

--- a/spec/1.3.0/bin/lib/transformations.py
+++ b/spec/1.3.0/bin/lib/transformations.py
@@ -126,7 +126,7 @@ SHORT_DATE_EXPR = re.compile(r'YYYY')
 
 
 def auto_dates(soup):
-    today = datetime.today().date()
+    today = datetime.utcnow().date()
     replace(soup, DATE_EXPR, fr'{today.year:04}\g<1>{today.month:02}\g<2>{today.day:02}')
     replace(soup, SHORT_DATE_EXPR, fr'{today.year:04}')
 

--- a/spec/1.3.0/bin/markydown-to-kramdown
+++ b/spec/1.3.0/bin/markydown-to-kramdown
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-version=1.3.0.4
+version=1.3.0.5
 
 RUN_OR_DOCKER_PULL=true
 

--- a/spec/1.3.0/bin/markydown-to-kramdown.pl
+++ b/spec/1.3.0/bin/markydown-to-kramdown.pl
@@ -6,14 +6,10 @@ use Encode;
 use YAML::PP;
 use XXX;
 
-my ($YYYY, $MM, $DD);
-
 sub main {
   my ($front, $markdown, $link_map) = read_files(@_);
 
   my $parsed = parse_sections($markdown);
-
-  set_vars();
 
   my @sections;
   for my $section (@$parsed) {
@@ -243,13 +239,9 @@ sub fmt_html_block {
   $_ = "$line$out";
 }
 
-sub fmt_heading {
-  set_dates();
-}
+sub fmt_heading {}
 
-sub fmt_dt {
-  set_dates();
-}
+sub fmt_dt {}
 
 sub fmt_example {
   my ($title, $yaml1, $yaml2, $legend) = @$_;
@@ -325,9 +317,7 @@ $out
 
 sub fmt_ul {}
 
-sub fmt_p {
-  set_dates();
-}
+sub fmt_p {}
 
 sub fmt_dd {
   s/^:\n(\S)/: $1/ or die $_;
@@ -384,14 +374,6 @@ sub read_file {
   <$fh>;
 }
 
-sub set_vars {
-  my ($d,$m,$y);
-  ($_,$_,$_,$d,$m,$y) = localtime;
-  $YYYY = 1900 + $y;
-  $MM = sprintf "%02d", $m + 1;
-  $DD = sprintf "%02d", $d;
-}
-
 sub slugify {
   my ($slug) = @_;
 
@@ -411,11 +393,6 @@ sub rule_link {
   my $rule = $text;
   $rule =~ s/\(.*//;
   return qq{<a href="#rule-$rule">$text<\/a>};
-}
-
-sub set_dates {
-  s/YYYY(.)MM(.)DD/$YYYY$1$MM$2$DD/g;
-  s/YYYY/$YYYY/g;
 }
 
 sub apply_highlights {


### PR DESCRIPTION
Turn `YYYY-MM-DD` and `YYYY` into the current date in Python rather than in m2k.

Also, explicitly use the UTC current date to make it location-invariant.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
