### PR TITLE
Use Python to format examples

### DIFF
--- a/spec/1.3.0/bin/html-to-html
+++ b/spec/1.3.0/bin/html-to-html
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-version=1.3.0.8
+version=1.3.0.9
 
 source "${ROOT:-$PWD}/.bpan/run-or-docker.bash"
 

--- a/spec/1.3.0/bin/lib/bs_util.py
+++ b/spec/1.3.0/bin/lib/bs_util.py
@@ -1,12 +1,15 @@
 from copy import copy
-from bs4 import BeautifulSoup, PageElement, NavigableString
+from bs4 import BeautifulSoup, PageElement, Tag, Comment, NavigableString
 
 
-__all__ = ['new_tag', 'replace']
+__all__ = ['new_tag', 'replace', 'next_tag', 'next_comments']
 
 
 def new_tag(soup, name, *contents, **attrs):
-    ret = soup.new_tag(name, **attrs)
+    ret = soup.new_tag(name, **{
+        key.rstrip('_'): value
+        for key, value in attrs.items()
+    })
     for child in flatten(contents):
         ret.append(child)
     return ret
@@ -72,3 +75,22 @@ def replace(element, expr, replacement):
             element.append(child)
         else:
             raise TypeError(type(child))
+
+
+def next_tag(start):
+    node = start
+    while node is not None:
+        node = node.next_sibling
+        if isinstance(node, Tag):
+            return node
+
+
+def next_comments(start):
+    node = start.next_sibling
+    while node is not None:
+        next_node = node.next_sibling
+        if isinstance(node, Comment):
+            yield node
+        elif isinstance(node, Tag):
+            return
+        node = next_node

--- a/spec/1.3.0/bin/lib/transformations.py
+++ b/spec/1.3.0/bin/lib/transformations.py
@@ -329,7 +329,11 @@ def format_examples(soup, production_names):
                         break
                     highlights.pop(0)
                     yield line[i:col_start]
-                    yield tag('mark', highlight_part(col_start, col_end), class_=f'legend-{mark_index}')
+                    yield tag(
+                        'mark',
+                        highlight_part(col_start, col_end),
+                        class_=f'legend-{mark_index}',
+                    )
                     i = col_end
                 yield line[i:parent_end]
 

--- a/spec/1.3.0/bin/markydown-to-kramdown
+++ b/spec/1.3.0/bin/markydown-to-kramdown
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-version=1.3.0.5
+version=1.3.0.6
 
 RUN_OR_DOCKER_PULL=true
 

--- a/spec/1.3.0/bin/markydown-to-kramdown.pl
+++ b/spec/1.3.0/bin/markydown-to-kramdown.pl
@@ -298,7 +298,7 @@ $yaml2
   }
 
   if ($legend) {
-    $_ = format_legend($legend);
+    $_ = $legend;
     $out .= <<"...";
 <div class="legend" markdown=1>
 $_
@@ -486,23 +486,6 @@ sub format_pre_json {
   $_ = $_[0];
   s/\n+\z/\n/;
   s/\A```\n/```json\n/;
-  return $_;
-}
-
-sub format_legend {
-  $_ = $_[0];
-  chomp;
-  s/\s*<!--.*-->//g;
-  my @lines = split /\n/, $_;
-  my $i = 1;
-  for (@lines) {
-    if (/^\*\ /) {
-      s{^\*\ (.*)}{* <code class="legend-$i">$1</code>}g;
-      $i++;
-    }
-  }
-  $_ = join "\n", @lines;
-  s{\[([^\]]+)\]}{rule_link($1)}ge;
   return $_;
 }
 

--- a/spec/1.3.0/spec.md
+++ b/spec/1.3.0/spec.md
@@ -1492,7 +1492,7 @@ folded: >
 ```
 
 **Legend:**
-* literal <!-- | -->
+* literal <!-- 1:10 -->
 * folded <!-- > -->
 
 "`'`" (`x27`, apostrophe, single quote) surrounds a [single-quoted flow


### PR DESCRIPTION
Format examples in the Python script rather m2k.

This is a surprisingly complex operation. The original m2k code did a lot, and there are a lot of corner cases. In the future, I'd like to eliminate some of those corner cases (or possibly redo the example formatting entirely), but for this PR the objective was producing as close to identical output with as close to identical input as possible.

Nevertheless:

- There is one tiny change in spec.md. Kramdown wanted to turn the line `* literal <!-- | -->` into a table, so I used indices for the comment to avoid this.
- Example 9.10. Folded Lines is highlighted differently using this PR. I'm pretty sure this was actually a bug in the old script.

Aside from these two points, the input and output are identical (verified with xmldiff).

N.B. The new implementation checks production links in examples, and there are several broken links that should be fixed in another PR.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.