### PR TITLE
Fix broken legend links

### DIFF
--- a/spec/1.3.0/bin/html-to-html
+++ b/spec/1.3.0/bin/html-to-html
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-version=1.3.0.9
+version=1.3.0.10
 
 source "${ROOT:-$PWD}/.bpan/run-or-docker.bash"
 

--- a/spec/1.3.0/bin/lib/transformations.py
+++ b/spec/1.3.0/bin/lib/transformations.py
@@ -270,8 +270,7 @@ def format_examples(soup, production_names):
         if production_match:
             name = production_match.group('name')
         else:
-            name = match[1]
-            warn(f"Warning: Invalid rule name {name}")
+            raise ValueError(f'Invalid rule name {match[1]}')
 
         if name not in production_names:
             warn(f"Warning: Can't find rule {name}")

--- a/spec/1.3.0/spec.md
+++ b/spec/1.3.0/spec.md
@@ -1963,7 +1963,7 @@ A folded non-[empty line] may end with either of the above [line breaks].
 ```
 
 **Legend:**
-* [trimmed] <!-- 2:10 3 4 5 -->
+* Trimmed spaces <!-- 2:10 3 4 5 -->
 * [break-as-space] <!-- 6:5 -->
 
 
@@ -4317,7 +4317,7 @@ null
 ```
 
 **Legend:**
-* [explicit-document] <!-- 1 2 3 5 6 -->
+* [start-indicator-and-document] <!-- 1 2 3 5 6 -->
 
 
 #### #. Directives Documents
@@ -4346,7 +4346,7 @@ null
 ```
 
 **Legend:**
-* [explicit-document] <!-- 1 2 3 5 6 7 -->
+* [start-indicator-and-document] <!-- 1 2 3 5 6 7 -->
 
 
 ### #. Streams
@@ -4380,7 +4380,7 @@ null
 **Legend:**
 * [any-document] <!-- 1 2 3 -->
 * [document-suffix] <!-- 4 -->
-* [explicit-document] <!-- 5 6 7 -->
+* [start-indicator-and-document] <!-- 5 6 7 -->
 
 
 A sequence of bytes is a _well-formed stream_ if, taken as a whole, it complies


### PR DESCRIPTION
While working on #254, I discovered that two of the legend links were broken:

- `trimmed`, which used to be `b-l-trimmed(n,c)`. Since the latter production was eliminated, I replaced `trimmed` with non-link text.
- `explicit-document`, which used to be `l-explicit-document`. I've updated those to the new name for that production, `start-indicator-and-document`.

This let me slightly simplify the error handling for legend links. Now, a link that isn't a valid rule name will raise an error. Previously, it was a warning because we had to let the invalid `trimmed` link through.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
