### PR TITLE
Use MD5 hash for version of html-to-html

### DIFF
--- a/.bpan/run-or-docker.bash
+++ b/.bpan/run-or-docker.bash
@@ -15,6 +15,7 @@ run() (
   self=$(basename "${BASH_SOURCE[1]}")
   root=${ROOT:-$PWD}
   prog=$(cd "$bin" && echo "$self".*)
+  version=${version:-$(calculate-version)}
   image=yamlio/$self:$version
 
   if [[ $prog == *'.*' ]]; then
@@ -333,6 +334,17 @@ build-docker-image() (
       docker push "$image"
     )
   fi
+)
+
+calculate-version() (
+  [[ ${uses-} ]] ||
+    die "'$0' requires either '\$version' variable or '\$uses' array"
+
+  cd "$(dirname "$0")" || exit
+
+  cat "${uses[@]}" |
+    md5sum |
+    cut -d' ' -f1
 )
 
 fail() { echo "FAIL: $*" >&2; exit 1; }

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - run: make test
+    - run: make verbose test
 
 # TODO: Make this on demand.
 #     - uses: mxschmitt/action-tmate@v3

--- a/spec/1.3.0/bin/html-to-html
+++ b/spec/1.3.0/bin/html-to-html
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 version=$(
-  cd $(dirname $0)
+  cd "$(dirname "$0")" || exit
   tar -cf - html-to-html html-to-html.py lib/* | md5sum | cut -d " " -f 1
-) >&2
+)
 
 source "${ROOT:-$PWD}/.bpan/run-or-docker.bash"
 

--- a/spec/1.3.0/bin/html-to-html
+++ b/spec/1.3.0/bin/html-to-html
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-version=1.3.0.11
+version=$(
+  cd $(dirname $0)
+  tar -cf - html-to-html html-to-html.py lib/* | md5sum | cut -d " " -f 1
+) >&2
 
 source "${ROOT:-$PWD}/.bpan/run-or-docker.bash"
 

--- a/spec/1.3.0/bin/html-to-html
+++ b/spec/1.3.0/bin/html-to-html
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 
-version=$(
-  cd "$(dirname "$0")" || exit
-  tar -cf - html-to-html html-to-html.py lib/* | md5sum | cut -d " " -f 1
+uses=(
+  html-to-html
+  html-to-html.py
+  lib/bs_util.py
+  lib/transformations.py
 )
 
 source "${ROOT:-$PWD}/.bpan/run-or-docker.bash"
 
 check() (
-  need python3 3.8
+  need python3 3.9
   need python bs4 roman yaml
 )
 


### PR DESCRIPTION
Each build script uses a `version` variable to select the correct version of the docker image. Previously, we've set these manually and incremented them for each PR. This is mildly inconvenient, but it also leads to the likelihood of conflict. If two PRs both increment a script's version, then one of them will clobber the other's docker image.

This PR replaces the `html-to-html` script's version number with a hash computed from the files the script depends on. This way, any change in the script will automatically cause the version to change. This should solve any possible conflict issues, as well as being more convenient.

If this approach works well for this script, then we might want to use it for others (probably integrating it into `run-or-docker.bash`). For now, this PR confines the change to just the `html-to-html` script.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
