### PR TITLE
Remove special case in legend code

### DIFF
--- a/spec/1.3.0/bin/lib/transformations.py
+++ b/spec/1.3.0/bin/lib/transformations.py
@@ -303,7 +303,7 @@ def format_examples(soup, production_names):
 
             if literal_parts:
                 pattern = r'|'.join(
-                    regexp_escape(part).removeprefix('0').replace('_', ' ')
+                    regexp_escape(part).replace('_', ' ')
                     for part in literal_parts
                 )
                 for row, line in enumerate(lines, 1):

--- a/spec/1.3.0/spec.md
+++ b/spec/1.3.0/spec.md
@@ -3446,7 +3446,7 @@ This is the only case where a [comment] must not be followed by additional
 ```
 
 **Legend:**
-* [block-scalar-indicators(t)] <!-- _#_Empty_header↓ 01_#_Indentation_indicator↓ +_#_Chomping_indicator↓ 01-_#_Both_indicators↓ -->
+* [block-scalar-indicators(t)] <!-- _#_Empty_header↓ 1_#_Indentation_indicator↓ +_#_Chomping_indicator↓ 1-_#_Both_indicators↓ -->
 
 
 ##### #. Block Indentation Indicator


### PR DESCRIPTION
Remove an unnecessary special case in the legend highlighting code. The resulting HTML is unchanged.

Marked as a draft because, anticipating #260, I didn't update the `version` in `html-to-html`.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
