### PR TITLE
Fix some problems with comment productions

### DIFF
--- a/spec/1.3.0/spec.md
+++ b/spec/1.3.0/spec.md
@@ -4627,7 +4627,7 @@ yaml-stream ::=
 ```
 document-prefix ::=
   byte-order-mark?
-  comment-line*
+  blanks-and-comment-line*
 ```
 
 ```
@@ -5005,10 +5005,7 @@ block-scalar-indicators(t) ::=
         block-scalar-indentation-indicator
       )
   )
-  (
-      comment-line
-    | line-ending
-  )
+  comment-line
 ```
 
 ```
@@ -5668,12 +5665,24 @@ folded-whitespace(n,c) ::=
 
 ```
 comment-lines ::=
-    comment-line+
+  (
+    comment-line
   | <start-of-line>
+  )
+  blanks-and-comment-line*
 ```
 
 ```
 comment-line ::=
+  (
+    separation-blanks
+    comment-content?
+  )?
+  line-ending
+```
+
+```
+blanks-and-comment-line ::=
   separation-blanks
   comment-content?
   line-ending


### PR DESCRIPTION
A few of the comment related production refactoring for 1.3.0 was incorrect.

These problems were found by test suite failures while making the reference implementation match these productions. 

See https://github.com/yaml/yaml-reference-parser/commit/e604dd5a9e8d4610b02e3438860d5cfe35fdf107

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
