### PR TITLE
Fix duplicate IDs

### DIFF
--- a/spec/1.3.0/bin/lib/bs_util.py
+++ b/spec/1.3.0/bin/lib/bs_util.py
@@ -2,7 +2,7 @@ from copy import copy
 from bs4 import BeautifulSoup, PageElement, Tag, Comment, NavigableString
 
 
-__all__ = ['new_tag', 'replace', 'next_tag', 'next_comments']
+__all__ = ['new_tag', 'replace', 'next_tag', 'next_comments', 'pretty_path']
 
 
 def new_tag(soup, name, *contents, **attrs):
@@ -94,3 +94,15 @@ def next_comments(start):
         elif isinstance(node, Tag):
             return
         node = next_node
+
+def pretty_element(element):
+    parts = [element.name]
+    if element.has_attr('id'):
+        parts.append('#' + element['id'])
+    return ''.join(parts)
+
+def pretty_path(element):
+    return ' → '.join(
+        pretty_element(p) for p in reversed([element, *element.parents])
+        if p.name != '[document]'
+    )

--- a/spec/1.3.0/bin/lib/transformations.py
+++ b/spec/1.3.0/bin/lib/transformations.py
@@ -1,11 +1,12 @@
 import sys
 import re
 import string
+import itertools
 from datetime import datetime
 
 from roman import toRoman
 
-from bs_util import new_tag, replace, next_tag, next_comments
+from bs_util import new_tag, replace, next_tag, next_comments, pretty_path
 
 from bs4 import Comment
 
@@ -21,6 +22,14 @@ def warn(*args):
 DOCUMENT = None
 def tag(name, *contents, **attrs):
     return new_tag(DOCUMENT, name, *contents, **attrs)
+
+
+def next_available_id(slug):
+    return next(
+        id
+        for id in itertools.chain([slug], (f'{slug}-{i}' for i in itertools.count(1)))
+        if DOCUMENT.find(id=id) is None
+    )
 
 
 HEADING_EXPR = re.compile(r'h(\d)')
@@ -92,6 +101,8 @@ def transform(soup, links):
 
     create_internal_links(soup, link_index)
 
+    check_for_duplicate_ids(soup)
+
 
 def make_outline(elements):
     stack = []
@@ -105,7 +116,7 @@ def make_outline(elements):
             while len(stack) >= level:
                 stack.pop()
 
-            section_id = slugify(''.join(element.strings))
+            section_id = next_available_id(slugify(''.join(element.strings)))
             section_attributes = {
                 name: value
                 for name, value in element.attrs.items()
@@ -121,7 +132,7 @@ def make_outline(elements):
 
 def auto_id_dts(soup):
     for dt in soup.find_all('dt'):
-        dt['id'] = slugify(''.join(dt.strings))
+        dt['id'] = next_available_id(slugify(''.join(dt.strings)))
 
 
 DATE_EXPR = re.compile(r'YYYY(.)MM(.)DD')
@@ -480,3 +491,15 @@ def create_internal_links(soup, link_index):
             return tag('a', target, href='#'+id)
 
     replace(soup, LINK_EXPR, replace_link)
+
+
+def check_for_duplicate_ids(soup):
+    grouped = {}
+    for element in soup.find_all(lambda tag: tag.has_attr('id')):
+        grouped.setdefault(element['id'], []).append(element)
+
+    for id, elements in grouped.items():
+        if len(elements) > 1:
+            warn(f"Warning: multiple elements with ID {id!r}")
+            for element in elements:
+                warn('    ' + pretty_path(element))

--- a/spec/1.3.0/spec.md
+++ b/spec/1.3.0/spec.md
@@ -2135,7 +2135,7 @@ Note that structures following multi-line comment separation must be properly
 [comment] lines themselves.
 
 
-**Example #. Separation Spaces**
+**Example #. Separation Lines**
 
 ```
 {·first:·Sammy,·last:·Sosa·}:↵


### PR DESCRIPTION
Fix #269.

Sections and definition terms are given autogenerated IDs. In some cases, these IDs were not unique. This is technically invalid HTML, and in addition, it broke some TOC links.

This PR adds a check when creating an autogenerated ID. If the ID already exists, the new ID will be given a numeric suffix. Since the TOC is generated based on the IDs, this fixes the broken TOC links. There is also a new check at the end that will produce warnings if there are any duplicate IDs in the document. Finally, this PR renames “Example 7.12. Separation Spaces” to “Separation Lines”. I think the previous name (a duplicate of an earlier example) was probably mistaken.

A large number of the previously conflicting IDs were definition terms. I think that some of them should be made headings instead, and the remainder probably don't need IDs at all. Another chunk of the duplicated IDs are from splitting out the productions, and many of them will naturally disappear as we revise the earlier parts. If a significant number still remain, it might make sense to add a common prefix to the IDs in the appendix.

The HTML diff is clean; the only changes are IDs, TOC hrefs, and the name of the one example.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
