### PR TITLE
Link headings to enclosing sections

### DIFF
--- a/spec/1.3.0/bin/lib/transformations.py
+++ b/spec/1.3.0/bin/lib/transformations.py
@@ -99,6 +99,8 @@ def transform(soup, links):
 
     toc_header.parent.insert_after(toc)
 
+    link_headings(soup)
+
     create_internal_links(soup, link_index)
 
     check_for_duplicate_ids(soup)
@@ -205,6 +207,16 @@ def number_figures(soup):
             )
             for i, figure_heading in enumerate(figure_headings, 1):
                 replace(figure_heading, HEADING_NUMBER_EXPR, '.'.join([chapter, str(i)]))
+
+
+def link_headings(soup):
+    for heading in soup.find_all(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']):
+        section = heading.find_parent('section')
+        if section is not None:
+            anchor = section.attrs.get('id', None)
+            if anchor is not None:
+                a = tag('a', [ch.extract() for ch in list(heading.children)], href='#'+anchor)
+                heading.append(a)
 
 
 PRODUCTION_EXPR = re.compile(r'''

--- a/www/main/spec.scss
+++ b/www/main/spec.scss
@@ -12,11 +12,17 @@ body.status-draft {
 
 a {
   color: inherit;
-  text-decoration: underline solid $theme-color;
+  text-decoration: underline solid currentcolor;
 
   &:hover {
     color: blue;
-    text-decoration: underline solid blue;
+  }
+}
+
+h1, h2, h3, h4, h5, h6 {
+  position: relative;
+  a {
+    text-decoration: none;
   }
 }
 


### PR DESCRIPTION
This should make it easier to get links to particular sections of the spec.

In the future, I'd like to do this for figures and examples as well. That might require improving the generated markup a bit.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
