### PR TITLE
Fix: #268. Remove timestamp examples

### DIFF
--- a/spec/1.3.0/spec.md
+++ b/spec/1.3.0/spec.md
@@ -494,15 +494,6 @@ string: '012345'
 ```
 
 
-**Example #. Timestamps**
-
-```
-canonical: 2001-12-15T02:59:43.1Z
-iso8601: 2001-12-14t21:59:43.10-05:00
-spaced: 2001-12-14 21:59:43.10 -5
-date: 2002-12-14
-```
-
 Explicit typing is denoted with a [tag] using the exclamation point ("`!`")
 symbol.
 [Global tags] are URIs and may be specified in a [tag shorthand] notation using


### PR DESCRIPTION
Note - this won't remove references to `timestamp` type.
* Issue #, if available: #268

* Description of changes: Remove the timestamp examples

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
