### PR TITLE
Update README: Fix spec reference directory

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -14,7 +14,7 @@ versions are defined.
 
 This repository contains the source code and build system for the [published
 YAML specification](https://yaml.org/).
-Versions 1.2 and newer are located under the `spec` directory.
+Versions 1.2 and older are located under the `spec` directory.
 
 The various components of the next YAML specification version will be added
 here incrementally following a well defined methodology.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -13,8 +13,8 @@ This repository is where the YAML language is further developed and the next
 versions are defined.
 
 This repository contains the source code and build system for the [published
-YAML 1.2 specification](https://yaml.org/spec/1.2/spec.html).
-Those files are under the `1.2` top level directory.
+YAML specification](https://yaml.org/).
+Versions 1.2 and newer are located under the `spec` directory.
 
 The various components of the next YAML specification version will be added
 here incrementally following a well defined methodology.


### PR DESCRIPTION
The directory reference was wrong, but also, more than just 1.2 is there.

<!-- The following lines must be present and unmodified for every pull request
     to this repository or the request will be closed -->
By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
