### PR TITLE
Add errata for text on plain scalar implicit keys

### DIFF
--- a/spec/1.2.2/ext/errata.md
+++ b/spec/1.2.2/ext/errata.md
@@ -1,3 +1,9 @@
 # YAML Specification 1.2.2 Errata
 
-* None yet reported
+7.3.3. Flow Scalar Styles / Plain Style
+:
+Removed the clause "or when used as implicit keys"
+as a situation when flow indicator characters may not be used in plain scalars.
+This does not reflect the spec rules,
+nor is it followed by any current implementation.
+(reported by @eemeli on 2023-08-26)

--- a/spec/1.2.2/spec.md
+++ b/spec/1.2.2/spec.md
@@ -4108,7 +4108,7 @@ ambiguity.
 Plain scalars must never contain the "`: `" and "` #`" character combinations.
 Such combinations would cause ambiguity with [mapping] [key/value pairs] and
 [comments].
-In addition, inside [flow collections], or when used as [implicit keys], plain
+In addition, inside [flow collections], plain
 scalars must not contain the "`[`", "`]`", "`{`", "`}`" and "`,`" characters.
 These characters would cause ambiguity with [flow collection] structures.
 


### PR DESCRIPTION
In 7.3.3 [the spec has](https://yaml.org/spec/1.2.2/#733-plain-style) (highlight added by me):

> Plain scalars must never contain the “: ” and “ #” character combinations. Such combinations would cause ambiguity with mapping key/value pairs and comments. In addition, inside flow collections, **_or when used as implicit keys_**, plain scalars must not contain the “[”, “]”, “{”, “}” and “,” characters. These characters would cause ambiguity with flow collection structures.

But then in a `BLOCK-KEY` context we use the `ns-plain-safe-out` rule, which doesn't rule out `c-flow-indicator` characters.

The text is wrong here, and should be fixed to match the rules. As further evidence of this, we have [test 2EBW](https://github.com/yaml/yaml-test-suite/blob/main/src/2EBW.yaml) allowing flow indicators in block map implicit keys; that's passed by all current implementations.

Fixing this disagreement by changing the rules would be a breaking change, so we can't do that.

For context, this was discovered while investigating eemeli/yaml#493, originally reported by @jedwards1211.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
